### PR TITLE
102X data config added

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Samples
 
-Preliminary recipe
+Preliminary recipe for 94X (also works with 80X samples)
 
 ```
 cmsrel CMSSW_9_4_10
@@ -19,6 +19,8 @@ cd $CMSSW_BASE/src
 scram b -j 8
 
 ```
+
+Do the same thing in CMSSW_10_2_5 for 2018 data.
 
 Checkout your custom modules to nanoAOD. This is just an example, adding the not yet merged computation of sumPt as well as FastSim support. sumPt is needed to recompute MET significance.
 

--- a/cfg/launch.py
+++ b/cfg/launch.py
@@ -2,11 +2,12 @@ import imp, os, sys
 from optparse import OptionParser
 import re
 
+from Samples.miniAOD.Spring16_miniAODv2 import allSamples as Spring16_miniAODv2
 from Samples.miniAOD.Summer16_miniAODv3 import allSamples as Summer16_miniAODv3
 from Samples.miniAOD.Summer16_miniAODv2 import allSamples as Summer16_miniAODv2
 from Samples.miniAOD.Run2016_17Jul2018 import allSamples as Run2016_17Jul2018
 
-allSamples = Summer16_miniAODv3 + Summer16_miniAODv2 + Run2016_17Jul2018
+allSamples = Spring16_miniAODv2 + Summer16_miniAODv3 + Summer16_miniAODv2 + Run2016_17Jul2018
 
 parser = OptionParser(usage="python launch.py [options] component1 [ component2 ...]", \
                           description="Launch heppy jobs with CRAB3. Components correspond to the variables defined in heppy_samples.py (their name attributes)")

--- a/cfg/launch.py
+++ b/cfg/launch.py
@@ -5,8 +5,10 @@ import re
 from Samples.miniAOD.Summer16_miniAODv3 import allSamples as Summer16_miniAODv3
 from Samples.miniAOD.Summer16_miniAODv2 import allSamples as Summer16_miniAODv2
 from Samples.miniAOD.Run2016_17Jul2018 import allSamples as Run2016_17Jul2018
+from Samples.miniAOD.Run2018_26Sep2018 import allSamples as Run2018_26Sep2018
 
-allSamples = Summer16_miniAODv3 + Summer16_miniAODv2 + Run2016_17Jul2018
+
+allSamples = Summer16_miniAODv3 + Summer16_miniAODv2 + Run2016_17Jul2018 + Run2018_26Sep2018
 
 parser = OptionParser(usage="python launch.py [options] component1 [ component2 ...]", \
                           description="Launch heppy jobs with CRAB3. Components correspond to the variables defined in heppy_samples.py (their name attributes)")
@@ -57,6 +59,8 @@ elif options.era == '80X_mc_fast':
     os.environ["CMSRUN_CFG"] = "test80X_fast_NANO.py"
 elif options.era == '94X_data':
     os.environ["CMSRUN_CFG"] = "test_data_94X_NANO.py"
+elif options.era == '102X_data':
+    os.environ["CMSRUN_CFG"] = "test_data_102X_NANO.py"
 else:
     raise NotImplementedError
 

--- a/cfg/launch.sh
+++ b/cfg/launch.sh
@@ -1,0 +1,22 @@
+#python launch.py --era 94X_data --production_label METSig_v1 --remoteDir METSig_v1 --unitsPerJob 1 --publish --sample DoubleMuon_Run2016B_17Jul2018_ver1
+#python launch.py --era 94X_data --production_label METSig_v1 --remoteDir METSig_v1 --unitsPerJob 1 --publish --sample DoubleMuon_Run2016B_17Jul2018_ver2
+#python launch.py --era 94X_data --production_label METSig_v1 --remoteDir METSig_v1 --unitsPerJob 1 --publish --sample DoubleMuon_Run2016C_17Jul2018
+#python launch.py --era 94X_data --production_label METSig_v1 --remoteDir METSig_v1 --unitsPerJob 1 --publish --sample DoubleMuon_Run2016D_17Jul2018
+#python launch.py --era 94X_data --production_label METSig_v1 --remoteDir METSig_v1 --unitsPerJob 1 --publish --sample DoubleMuon_Run2016E_17Jul2018
+#python launch.py --era 94X_data --production_label METSig_v1 --remoteDir METSig_v1 --unitsPerJob 1 --publish --sample DoubleMuon_Run2016F_17Jul2018
+#python launch.py --era 94X_data --production_label METSig_v1 --remoteDir METSig_v1 --unitsPerJob 1 --publish --sample DoubleMuon_Run2016G_17Jul2018
+#python launch.py --era 94X_data --production_label METSig_v1 --remoteDir METSig_v1 --unitsPerJob 1 --publish --sample DoubleMuon_Run2016H_17Jul2018
+
+python launch.py --era 102X_data --production_label HEM_v1 --remoteDir HEM_v1 --unitsPerJob 1 --publish --sample MuonEG_Run2018B_26Sep2018
+python launch.py --era 102X_data --production_label HEM_v1 --remoteDir HEM_v1 --unitsPerJob 1 --publish --sample MuonEG_Run2018B_26Sep2018_HEM
+python launch.py --era 102X_data --production_label HEM_v1 --remoteDir HEM_v1 --unitsPerJob 1 --publish --sample MuonEG_Run2018B_26Sep2018_HEMmitigation
+
+python launch.py --era 102X_data --production_label HEM_v1 --remoteDir HEM_v1 --unitsPerJob 1 --publish --sample EGamma_Run2018B_26Sep2018
+python launch.py --era 102X_data --production_label HEM_v1 --remoteDir HEM_v1 --unitsPerJob 1 --publish --sample EGamma_Run2018B_26Sep2018_HEM
+python launch.py --era 102X_data --production_label HEM_v1 --remoteDir HEM_v1 --unitsPerJob 1 --publish --sample EGamma_Run2018B_26Sep2018_HEMmitigation
+
+#python launch.py --era 102X_data --production_label HEM_v1 --remoteDir HEM_v1 --unitsPerJob 1 --publish --sample DoubleMuon_Run2018B_26Sep2018
+#python launch.py --era 102X_data --production_label HEM_v1 --remoteDir HEM_v1 --unitsPerJob 1 --publish --sample DoubleMuon_Run2018B_26Sep2018_HEM
+#python launch.py --era 102X_data --production_label HEM_v1 --remoteDir HEM_v1 --unitsPerJob 1 --publish --sample DoubleMuon_Run2018B_26Sep2018_HEMmitigation
+
+

--- a/cfg/test80X_fast_NANO.py
+++ b/cfg/test80X_fast_NANO.py
@@ -27,7 +27,8 @@ process.maxEvents = cms.untracked.PSet(
 
 # Input source
 process.source = cms.Source("PoolSource",
-    fileNames = cms.untracked.vstring('/store/mc/RunIISummer16MiniAODv2/DYJetsToLL_M-50_TuneCUETP8M1_13TeV-madgraphMLM-pythia8/MINIAODSIM/LHE_PUSummer16Fast_80X_mcRun2_asymptotic_2016_TrancheIV_v6_ext1-v1/120000/36AFFDE1-E5F3-E611-BE11-02163E01310E.root'),
+#    fileNames = cms.untracked.vstring('/store/mc/RunIISummer16MiniAODv2/DYJetsToLL_M-50_TuneCUETP8M1_13TeV-madgraphMLM-pythia8/MINIAODSIM/LHE_PUSummer16Fast_80X_mcRun2_asymptotic_2016_TrancheIV_v6_ext1-v1/120000/36AFFDE1-E5F3-E611-BE11-02163E01310E.root'),
+    fileNames = cms.untracked.vstring('/store/mc/RunIISpring16MiniAODv2/SMS-T2tt_mStop-400to1200_TuneCUETP8M1_13TeV-madgraphMLM-pythia8/MINIAODSIM/PUSpring16Fast_80X_mcRun2_asymptotic_2016_miniAODv2_v0-v1/70000/F2C4BA5D-8234-E611-8B80-002590D9D8BC.root'),
     secondaryFileNames = cms.untracked.vstring()
 )
 

--- a/cfg/test_data_102X_NANO.py
+++ b/cfg/test_data_102X_NANO.py
@@ -1,0 +1,91 @@
+# Auto generated configuration file
+# using: 
+# Revision: 1.19 
+# Source: /local/reps/CMSSW/CMSSW/Configuration/Applications/python/ConfigBuilder.py,v 
+# with command line options: test_data_102X -s NANO --data --eventcontent NANOAOD --datatier NANOAOD --filein /store/data/Run2018B/DoubleMuon/MINIAOD/26Sep2018_HEMmitigation-v1/270000/3C707CC4-770A-1B4A-9E33-B6DAFD1E9FC6.root --conditions 102X_dataRun2_Prompt_v6 -n 100 --era Run2_2018
+import FWCore.ParameterSet.Config as cms
+
+from Configuration.StandardSequences.Eras import eras
+
+process = cms.Process('NANO',eras.Run2_2018)
+
+# import of standard configurations
+process.load('Configuration.StandardSequences.Services_cff')
+process.load('SimGeneral.HepPDTESSource.pythiapdt_cfi')
+process.load('FWCore.MessageService.MessageLogger_cfi')
+process.load('Configuration.EventContent.EventContent_cff')
+process.load('Configuration.StandardSequences.GeometryRecoDB_cff')
+process.load('Configuration.StandardSequences.MagneticField_AutoFromDBCurrent_cff')
+process.load('PhysicsTools.NanoAOD.nano_cff')
+process.load('Configuration.StandardSequences.EndOfProcess_cff')
+process.load('Configuration.StandardSequences.FrontierConditions_GlobalTag_cff')
+
+process.maxEvents = cms.untracked.PSet(
+    input = cms.untracked.int32(100)
+)
+
+# Input source
+process.source = cms.Source("PoolSource",
+    #fileNames = cms.untracked.vstring('/store/data/Run2018B/DoubleMuon/MINIAOD/26Sep2018_HEMmitigation-v1/270000/3C707CC4-770A-1B4A-9E33-B6DAFD1E9FC6.root'),
+    fileNames = cms.untracked.vstring('/store/data/Run2018B/EGamma/MINIAOD/26Sep2018-v1/00000/28B96E28-CAE3-7348-9BDD-A0CE24015884.root'),
+    #fileNames = cms.untracked.vstring('/store/data/Run2018D/DoubleMuon/MINIAOD/PromptReco-v2/000/320/569/00000/54C814A5-1C96-E811-AAD0-FA163ECB6866.root'),
+    secondaryFileNames = cms.untracked.vstring()
+)
+
+process.options = cms.untracked.PSet(
+
+)
+
+# Production Info
+process.configurationMetadata = cms.untracked.PSet(
+    annotation = cms.untracked.string('test_data_102X nevts:100'),
+    name = cms.untracked.string('Applications'),
+    version = cms.untracked.string('$Revision: 1.19 $')
+)
+
+# Output definition
+
+process.NANOAODoutput = cms.OutputModule("NanoAODOutputModule",
+    compressionAlgorithm = cms.untracked.string('LZMA'),
+    compressionLevel = cms.untracked.int32(9),
+    dataset = cms.untracked.PSet(
+        dataTier = cms.untracked.string('NANOAOD'),
+        filterName = cms.untracked.string('')
+    ),
+    fileName = cms.untracked.string('nanoAOD.root'),
+    fakeNameForCrab =cms.untracked.bool(True),
+    outputCommands = process.NANOAODEventContent.outputCommands
+)
+
+# Additional output definition
+
+# Other statements
+from Configuration.AlCa.GlobalTag import GlobalTag
+process.GlobalTag = GlobalTag(process.GlobalTag, '102X_dataRun2_Prompt_v6', '')
+
+# Path and EndPath definitions
+process.nanoAOD_step = cms.Path(process.nanoSequence)
+process.endjob_step = cms.EndPath(process.endOfProcess)
+process.NANOAODoutput_step = cms.EndPath(process.NANOAODoutput)
+
+# Schedule definition
+process.schedule = cms.Schedule(process.nanoAOD_step,process.endjob_step,process.NANOAODoutput_step)
+from PhysicsTools.PatAlgos.tools.helpers import associatePatAlgosToolsTask
+associatePatAlgosToolsTask(process)
+
+# customisation of the process.
+
+# Automatic addition of the customisation function from PhysicsTools.NanoAOD.nano_cff
+from PhysicsTools.NanoAOD.nano_cff import nanoAOD_customizeData 
+
+#call to customisation function nanoAOD_customizeData imported from PhysicsTools.NanoAOD.nano_cff
+process = nanoAOD_customizeData(process)
+
+# End of customisation functions
+
+# Customisation from command line
+
+# Add early deletion of temporary data products to reduce peak memory need
+from Configuration.StandardSequences.earlyDeleteSettings_cff import customiseEarlyDelete
+process = customiseEarlyDelete(process)
+# End adding early deletion

--- a/miniAOD/python/Run2018_26Sep2018.py
+++ b/miniAOD/python/Run2018_26Sep2018.py
@@ -1,0 +1,39 @@
+from Samples.Tools.Sample import Sample
+
+## DoubleMuon
+DoubleMuon_Run2018B_26Sep2018               = Sample("DoubleMuon_Run2018B_26Sep2018",               "/DoubleMuon/Run2018B-26Sep2018-v1/MINIAOD")
+DoubleMuon_Run2018B_26Sep2018_HEM           = Sample("DoubleMuon_Run2018B_26Sep2018_HEM",           "/DoubleMuon/Run2018B-26Sep2018_HEM-v1/MINIAOD")
+DoubleMuon_Run2018B_26Sep2018_HEMmitigation = Sample("DoubleMuon_Run2018B_26Sep2018_HEMmitigation", "/DoubleMuon/Run2018B-26Sep2018_HEMmitigation-v1/MINIAOD")
+
+DoubleMuon = [
+    DoubleMuon_Run2018B_26Sep2018,
+    DoubleMuon_Run2018B_26Sep2018_HEM,
+    DoubleMuon_Run2018B_26Sep2018_HEMmitigation,
+]
+
+# MuonEG
+MuonEG_Run2018B_26Sep2018               = Sample("MuonEG_Run2018B_26Sep2018",               "/MuonEG/Run2018B-26Sep2018-v1/MINIAOD")
+MuonEG_Run2018B_26Sep2018_HEM           = Sample("MuonEG_Run2018B_26Sep2018_HEM",           "/MuonEG/Run2018B-26Sep2018_HEM-v1/MINIAOD")
+MuonEG_Run2018B_26Sep2018_HEMmitigation = Sample("MuonEG_Run2018B_26Sep2018_HEMmitigation", "/MuonEG/Run2018B-26Sep2018_HEMmitigation-v1/MINIAOD")
+
+MuonEG = [
+    MuonEG_Run2018B_26Sep2018,
+    MuonEG_Run2018B_26Sep2018_HEM,
+    MuonEG_Run2018B_26Sep2018_HEMmitigation,
+]
+
+# EGamma
+EGamma_Run2018B_26Sep2018               = Sample("EGamma_Run2018B_26Sep2018",               "/EGamma/Run2018B-26Sep2018-v1/MINIAOD")
+EGamma_Run2018B_26Sep2018_HEM           = Sample("EGamma_Run2018B_26Sep2018_HEM",           "/EGamma/Run2018B-26Sep2018_HEM-v1/MINIAOD")
+EGamma_Run2018B_26Sep2018_HEMmitigation = Sample("EGamma_Run2018B_26Sep2018_HEMmitigation", "/EGamma/Run2018B-26Sep2018_HEMmitigation-v1/MINIAOD")
+
+EGamma = [ 
+    EGamma_Run2018B_26Sep2018,
+    EGamma_Run2018B_26Sep2018_HEM,
+    EGamma_Run2018B_26Sep2018_HEMmitigation,
+]
+
+
+## sum up
+allSamples = DoubleMuon + MuonEG + EGamma
+

--- a/miniAOD/python/Spring16_miniAODv2.py
+++ b/miniAOD/python/Spring16_miniAODv2.py
@@ -1,0 +1,19 @@
+'''
+miniAOD samples of Summer16 campaign, miniAODv2 (80X)
+Get the full list of samples with
+dasgoclient -query="dataset=/*/RunIISummer16*80X*/MINIAODSIM"
+'''
+
+from Samples.Tools.Sample import Sample
+
+
+## DY
+SMS_T2tt_mStop400to1200_FS_S16_80X       = Sample("SMS_T2tt_mStop400to1200_FS_S16_80X",  "/SMS-T2tt_mStop-400to1200_TuneCUETP8M1_13TeV-madgraphMLM-pythia8/RunIISpring16MiniAODv2-PUSpring16Fast_80X_mcRun2_asymptotic_2016_miniAODv2_v0-v1/MINIAODSIM")
+
+
+signals = [
+    SMS_T2tt_mStop400to1200_FS_S16_80X,
+]
+
+allSamples = signals
+


### PR DESCRIPTION
Added a cfg file for 102X, usable for 2018 data and the special samples for HEM studies.
- cfg for 102X added
- miniAOD samples for HEM study added (Run2018B)
- Spring16 SUSY FastSim scans added