### PR TITLE
Missing miniAOD samples added

### DIFF
--- a/cfg/crabManager.py
+++ b/cfg/crabManager.py
@@ -78,5 +78,8 @@ print "Unknonw status:", nUnknown
 print
 print "These datasets have been processed:"
 for d in datasets:
-    print d['input'], '   ---->    ', eval(d['output'])[0]
+    if d.has_key('output'):
+        print d['input'], '   ---->    ', eval(d['output'])[0]
+    else:
+        print d['input'], '   ---->    ', 'No output yet'
 

--- a/miniAOD/python/Autumn18_miniAODv1.py
+++ b/miniAOD/python/Autumn18_miniAODv1.py
@@ -17,6 +17,51 @@ relvals = [
 ]
 
 
+DYJetsToLL_M50_FXFX_A18_102X    = Sample("DYJetsToLL_M50_FXFX_A18_102X", "/DYJetsToLL_M-50_TuneCP5_13TeV-amcatnloFXFX-pythia8/RunIIAutumn18MiniAOD-102X_upgrade2018_realistic_v15-v1/MINIAODSIM")
+DYJetsToLL_M50_MLM_A18_102X     = Sample("DYJetsToLL_M50_MLM_S16_94X_ext1", "/DYJetsToLL_M-50_TuneCP5_13TeV-madgraphMLM-pythia8/RunIIAutumn18MiniAOD-102X_upgrade2018_realistic_v15-v1/MINIAODSIM")
+
+DY = [
+    DYJetsToLL_M50_FXFX_A18_102X,
+    DYJetsToLL_M50_MLM_A18_102X,
+]
 
 
-allSamples = relvals
+TT_DiLept_amc_A18_102X      = Sample("TT_DiLept_amc_A18_102X", "/TT_DiLept_TuneCP5_13TeV-amcatnlo-pythia8/RunIIAutumn18MiniAOD-102X_upgrade2018_realistic_v15_ext1-v2/MINIAODSIM")
+TTTo2L2Nu_pow_A18_102X      = Sample("TTTo2L2Nu_pow_A18_102X", "/TTTo2L2Nu_TuneCP5_13TeV-powheg-pythia8/RunIIAutumn18MiniAOD-102X_upgrade2018_realistic_v15-v1/MINIAODSIM")
+TTToHadronic_pow_A18_102X   = Sample("TTToHadronic_pow_A18_102X", "/TTToHadronic_TuneCP5_13TeV-powheg-pythia8/RunIIAutumn18MiniAOD-102X_upgrade2018_realistic_v15-v1/MINIAODSIM")
+ST_schannel_A18_102X        = Sample("ST_schannel_A18_102X", "/ST_s-channel_4f_hadronicDecays_TuneCP5_13TeV-madgraph-pythia8/RunIIAutumn18MiniAOD-102X_upgrade2018_realistic_v15_ext1-v1/MINIAODSIM")
+TTWZ_A18_102X               = Sample("TTWZ_A18_102X", "/TTWZ_TuneCP5_13TeV-madgraph-pythia8/RunIIAutumn18MiniAOD-102X_upgrade2018_realistic_v15_ext1-v2/MINIAODSIM")
+TTHH_A18_102X               = Sample("TTHH_A18_102X", "/TTHH_TuneCP5_13TeV-madgraph-pythia8/RunIIAutumn18MiniAOD-102X_upgrade2018_realistic_v15_ext1-v2/MINIAODSIM")
+
+top = [
+    TT_DiLept_amc_A18_102X,
+    TTTo2L2Nu_pow_A18_102X,
+    TTToHadronic_pow_A18_102X,
+    ST_schannel_A18_102X,
+    TTWZ_A18_102X,
+    TTHH_A18_102X,
+]
+
+
+WW_A18_102X             = Sample("WW_A18_102X", "/WW_TuneCP5_13TeV-pythia8/RunIIAutumn18MiniAOD-102X_upgrade2018_realistic_v15-v2/MINIAODSIM")
+ZZ_A18_102X             = Sample("ZZ_A18_102X", "/ZZ_TuneCP5_13TeV-pythia8/RunIIAutumn18MiniAOD-102X_upgrade2018_realistic_v15-v2/MINIAODSIM")
+ZH_HToBB_ZToLL_A18_102X = Sample("ZH_HToBB_ZToLL_A18_102X", "/ZH_HToBB_ZToLL_M125_13TeV_powheg_pythia8/RunIIAutumn18MiniAOD-102X_upgrade2018_realistic_v15-v2/MINIAODSIM")
+
+diboson = [
+    WW_A18_102X,
+    ZZ_A18_102X,
+    ZH_HToBB_ZToLL_A18_102X,
+]
+
+
+WWZ_A18_102X            = Sample("WWZ_A18_102X", "/WWZ_TuneCP5_13TeV-amcatnlo-pythia8/RunIIAutumn18MiniAOD-102X_upgrade2018_realistic_v15_ext1-v2/MINIAODSIM")
+WZZ_A18_102X            = Sample("WZZ_A18_102X", "/WZZ_TuneCP5_13TeV-amcatnlo-pythia8/RunIIAutumn18MiniAOD-102X_upgrade2018_realistic_v15_ext1-v2/MINIAODSIM")
+ZZZ_A18_102X            = Sample("ZZZ_A18_102X", "/ZZZ_TuneCP5_13TeV-amcatnlo-pythia8/RunIIAutumn18MiniAOD-102X_upgrade2018_realistic_v15_ext1-v2/MINIAODSIM")
+
+multiboson = [
+    WWZ_A18_102X,
+    WZZ_A18_102X,
+    ZZZ_A18_102X,
+]
+
+allSamples = relvals + DY + top + diboson + multiboson

--- a/miniAOD/python/Fall17_miniAODv2.py
+++ b/miniAOD/python/Fall17_miniAODv2.py
@@ -1,51 +1,270 @@
 '''
 miniAOD samples of Fall17 campaign, miniAODv2 (94X)
 Get the full list of samples with
-dasgoclient -query="dataset=/*/RunIISummer16MiniAODv2*80X*/MINIAODSIM"
+dasgoclient -query="dataset=/*TuneCP5*/RunIIFall17MiniAODv2*/MINIAODSIM"
 '''
 
 from Samples.Tools.Sample import Sample
 
 
 ## DY
-DYJetsToLL_M50_MLM_F17_94X          = Sample("DYJetsToLL_M50_MLM_F17_94X",     "/DYJetsToLL_M-50_TuneCP5_13TeV-madgraphMLM-pythia8/RunIIFall17MiniAODv2-PU2017RECOSIMstep_12Apr2018_94X_mc2017_realistic_v14-v1/MINIAODSIM")
+
+# low mass
+DYJetsToLL_M10to50_MLM_F17_94X              = Sample("DYJetsToLL_M10to50_MLM_F17_94X",              "/DYJetsToLL_M-10to50_TuneCP5_13TeV-madgraphMLM-pythia8/RunIIFall17MiniAODv2-PU2017_12Apr2018_94X_mc2017_realistic_v14-v1/MINIAODSIM")
+
+DYJetsToLL_M10to50_HT100to200_F17_94X       = Sample("DYJetsToLL_M4to50_HT100to200_F17_94X",        "/DYJetsToLL_M-4to50_HT-100to200_TuneCP5_13TeV-madgraphMLM-pythia8/RunIIFall17MiniAODv2-PU2017_12Apr2018_94X_mc2017_realistic_v14-v1/MINIAODSIM")
+DYJetsToLL_M10to50_HT100to200_F17_94X_ext1  = Sample("DYJetsToLL_M4to50_HT100to200_F17_94X_ext1",   "/DYJetsToLL_M-4to50_HT-100to200_TuneCP5_13TeV-madgraphMLM-pythia8/RunIIFall17MiniAODv2-PU2017_12Apr2018_94X_mc2017_realistic_v14_ext1-v1/MINIAODSIM")
+DYJetsToLL_M10to50_HT200to400_F17_94X       = Sample("DYJetsToLL_M10to50_HT200to400_F17_94X",       "/DYJetsToLL_M-4to50_HT-200to400_TuneCP5_13TeV-madgraphMLM-pythia8/RunIIFall17MiniAODv2-PU2017_12Apr2018_new_pmx_94X_mc2017_realistic_v14-v1/MINIAODSIM")
+DYJetsToLL_M10to50_HT200to400_F17_94X_ext1  = Sample("DYJetsToLL_M10to50_HT200to400_F17_94X_ext1",  "/DYJetsToLL_M-4to50_HT-200to400_TuneCP5_13TeV-madgraphMLM-pythia8/RunIIFall17MiniAODv2-PU2017_12Apr2018_94X_mc2017_realistic_v14_ext1-v1/MINIAODSIM")
+DYJetsToLL_M10to50_HT400to600_F17_94X       = Sample("DYJetsToLL_M10to50_HT400to600_F17_94X",       "/DYJetsToLL_M-4to50_HT-400to600_TuneCP5_13TeV-madgraphMLM-pythia8/RunIIFall17MiniAODv2-PU2017_12Apr2018_94X_mc2017_realistic_v14-v1/MINIAODSIM")
+DYJetsToLL_M10to50_HT400to600_F17_94X_ext1  = Sample("DYJetsToLL_M10to50_HT400to600_F17_94X_ext1",  "/DYJetsToLL_M-4to50_HT-400to600_TuneCP5_13TeV-madgraphMLM-pythia8/RunIIFall17MiniAODv2-PU2017_12Apr2018_94X_mc2017_realistic_v14_ext1-v1/MINIAODSIM")
+DYJetsToLL_M10to50_HT600toInf_F17_94X       = Sample("DYJetsToLL_M10to50_HT600toInf_F17_94X",       "/DYJetsToLL_M-4to50_HT-600toInf_TuneCP5_13TeV-madgraphMLM-pythia8/RunIIFall17MiniAODv2-PU2017_12Apr2018_94X_mc2017_realistic_v14-v1/MINIAODSIM")
+DYJetsToLL_M10to50_HT600toInf_F17_94X_ext1  = Sample("DYJetsToLL_M10to50_HT600toInf_F17_94X_ext1",  "/DYJetsToLL_M-4to50_HT-600toInf_TuneCP5_13TeV-madgraphMLM-pythia8/RunIIFall17MiniAODv2-PU2017_12Apr2018_94X_mc2017_realistic_v14_ext1-v1/MINIAODSIM")
+
+# high mass
+DYJetsToLL_M50_FXFX_F17_94X                 = Sample("DYJetsToLL_M50_FXFX_F17_94X",                 "/DYJetsToLL_M-50_TuneCP5_13TeV-amcatnloFXFX-pythia8/RunIIFall17MiniAODv2-PU2017_12Apr2018_new_pmx_94X_mc2017_realistic_v14_ext1-v1/MINIAODSIM")
+DYJetsToLL_M50_MLM_F17_94X                  = Sample("DYJetsToLL_M50_MLM_F17_94X",                  "/DYJetsToLL_M-50_TuneCP5_13TeV-madgraphMLM-pythia8/RunIIFall17MiniAODv2-PU2017RECOSIMstep_12Apr2018_94X_mc2017_realistic_v14-v1/MINIAODSIM")
+DYJetsToLL_M50_MLM_F17_94X_ext1             = Sample("DYJetsToLL_M50_MLM_F17_94X_ext1",             "/DYJetsToLL_M-50_TuneCP5_13TeV-madgraphMLM-pythia8/RunIIFall17MiniAODv2-PU2017RECOSIMstep_12Apr2018_94X_mc2017_realistic_v14_ext1-v1/MINIAODSIM")
+
+DYJetsToLL_M50_HT70to100_F17_94X            = Sample("DYJetsToLL_M50_HT70to100_F17_94X",            "/DYJetsToLL_M-50_HT-70to100_TuneCP5_13TeV-madgraphMLM-pythia8/RunIIFall17MiniAODv2-PU2017_12Apr2018_94X_mc2017_realistic_v14-v1/MINIAODSIM")
+DYJetsToLL_M50_HT100to200_F17_94X           = Sample("DYJetsToLL_M50_HT100to200_F17_94X",           "/DYJetsToLL_M-50_HT-100to200_TuneCP5_13TeV-madgraphMLM-pythia8/RunIIFall17MiniAODv2-PU2017_12Apr2018_new_pmx_94X_mc2017_realistic_v14-v2/MINIAODSIM")
+DYJetsToLL_M50_HT100to200_F17_94X_ext1      = Sample("DYJetsToLL_M50_HT100to200_F17_94X_ext1",      "/DYJetsToLL_M-50_HT-100to200_TuneCP5_13TeV-madgraphMLM-pythia8/RunIIFall17MiniAODv2-PU2017_12Apr2018_94X_mc2017_realistic_v14_ext1-v1/MINIAODSIM")
+DYJetsToLL_M50_HT200to400_F17_94X           = Sample("DYJetsToLL_M50_HT200to400_F17_94X",           "/DYJetsToLL_M-50_HT-200to400_TuneCP5_13TeV-madgraphMLM-pythia8/RunIIFall17MiniAODv2-PU2017_12Apr2018_94X_mc2017_realistic_v14-v2/MINIAODSIM")
+DYJetsToLL_M50_HT200to400_F17_94X_ext1      = Sample("DYJetsToLL_M50_HT200to400_F17_94X_ext1",      "/DYJetsToLL_M-50_HT-200to400_TuneCP5_13TeV-madgraphMLM-pythia8/RunIIFall17MiniAODv2-PU2017_12Apr2018_94X_mc2017_realistic_v14_ext1-v1/MINIAODSIM")
+DYJetsToLL_M50_HT400to600_F17_94X           = Sample("DYJetsToLL_M50_HT400to600_F17_94X",           "/DYJetsToLL_M-50_HT-400to600_TuneCP5_13TeV-madgraphMLM-pythia8/RunIIFall17MiniAODv2-PU2017_12Apr2018_new_pmx_94X_mc2017_realistic_v14-v2/MINIAODSIM")
+DYJetsToLL_M50_HT400to600_F17_94X_ext1      = Sample("DYJetsToLL_M50_HT400to600_F17_94X_ext1",      "/DYJetsToLL_M-50_HT-400to600_TuneCP5_13TeV-madgraphMLM-pythia8/RunIIFall17MiniAODv2-PU2017_12Apr2018_94X_mc2017_realistic_v14_ext1-v1/MINIAODSIM")
+DYJetsToLL_M50_HT600to800_F17_94X           = Sample("DYJetsToLL_M50_HT600to800_F17_94X",           "/DYJetsToLL_M-50_HT-600to800_TuneCP5_13TeV-madgraphMLM-pythia8/RunIIFall17MiniAODv2-PU2017_12Apr2018_new_pmx_94X_mc2017_realistic_v14-v2/MINIAODSIM")
+DYJetsToLL_M50_HT800to1200_F17_94X          = Sample("DYJetsToLL_M50_HT800to1200_F17_94X",          "/DYJetsToLL_M-50_HT-800to1200_TuneCP5_13TeV-madgraphMLM-pythia8/RunIIFall17MiniAODv2-PU2017_12Apr2018_new_pmx_94X_mc2017_realistic_v14-v2/MINIAODSIM")
+DYJetsToLL_M50_HT1200to2500_F17_94X         = Sample("DYJetsToLL_M50_HT1200to2500_F17_94X",         "/DYJetsToLL_M-50_HT-1200to2500_TuneCP5_13TeV-madgraphMLM-pythia8/RunIIFall17MiniAODv2-PU2017_12Apr2018_94X_mc2017_realistic_v14-v1/MINIAODSIM")
+DYJetsToLL_M50_HT2500toIng_F17_94X          = Sample("DYJetsToLL_M50_HT2500toIng_F17_94X",          "/DYJetsToLL_M-50_HT-2500toInf_TuneCP5_13TeV-madgraphMLM-pythia8/RunIIFall17MiniAODv2-PU2017_12Apr2018_new_pmx_94X_mc2017_realistic_v14-v2/MINIAODSIM")
 
 DY = [
+    DYJetsToLL_M10to50_MLM_F17_94X,
+    DYJetsToLL_M10to50_HT100to200_F17_94X,
+    DYJetsToLL_M10to50_HT100to200_F17_94X_ext1,
+    DYJetsToLL_M10to50_HT200to400_F17_94X,
+    DYJetsToLL_M10to50_HT200to400_F17_94X_ext1,
+    DYJetsToLL_M10to50_HT400to600_F17_94X,
+    DYJetsToLL_M10to50_HT400to600_F17_94X_ext1,
+    DYJetsToLL_M10to50_HT600toInf_F17_94X,
+    DYJetsToLL_M10to50_HT600toInf_F17_94X_ext1,
+    DYJetsToLL_M50_FXFX_F17_94X,
     DYJetsToLL_M50_MLM_F17_94X,
+    DYJetsToLL_M50_MLM_F17_94X_ext1,
+    DYJetsToLL_M50_HT70to100_F17_94X,
+    DYJetsToLL_M50_HT100to200_F17_94X,
+    DYJetsToLL_M50_HT100to200_F17_94X_ext1,
+    DYJetsToLL_M50_HT200to400_F17_94X,
+    DYJetsToLL_M50_HT200to400_F17_94X_ext1,
+    DYJetsToLL_M50_HT400to600_F17_94X,
+    DYJetsToLL_M50_HT400to600_F17_94X_ext1,
+    DYJetsToLL_M50_HT600to800_F17_94X,
+    DYJetsToLL_M50_HT800to1200_F17_94X,
+    DYJetsToLL_M50_HT1200to2500_F17_94X,
+    DYJetsToLL_M50_HT2500toIng_F17_94X,
 ]
 
-## TTJets
+# single top
+ST_schannel_4f_amc_F17_94X                      = Sample("ST_schannel_4f_amc_F17_94X",                  "/ST_s-channel_4f_leptonDecays_TuneCP5_13TeV-amcatnlo-pythia8/RunIIFall17MiniAODv2-PU2017_12Apr2018_94X_mc2017_realistic_v14-v2/MINIAODSIM")
+ST_schannel_4f_amc_PS_F17_94X                   = Sample("ST_schannel_4f_amc_PS_F17_94X",               "/ST_s-channel_4f_leptonDecays_TuneCP5_PSweights_13TeV-amcatnlo-pythia8/RunIIFall17MiniAODv2-PU2017_12Apr2018_new_pmx_94X_mc2017_realistic_v14-v1/MINIAODSIM")
+ST_tchannel_antitop_4f_incl_pow_F17_94X         = Sample("ST_tchannel_antitop_4f_incl_pow_F17_94X",     "/ST_t-channel_antitop_4f_inclusiveDecays_TuneCP5_13TeV-powhegV2-madspin-pythia8/RunIIFall17MiniAODv2-PU2017_12Apr2018_94X_mc2017_realistic_v14-v2/MINIAODSIM")
+ST_tchannel_antitop_5f_pow_PS_F17_94X           = Sample("ST_tchannel_antitop_5f_pow_PS_F17_94X",       "/ST_t-channel_antitop_5f_TuneCP5_PSweights_13TeV-powheg-pythia8/RunIIFall17MiniAODv2-PU2017_12Apr2018_new_pmx_94X_mc2017_realistic_v14-v1/MINIAODSIM")
+ST_tchannel_top_4f_incl_pow_F17_94X             = Sample("ST_tchannel_top_4f_incl_pow_F17_94X",         "/ST_t-channel_top_4f_inclusiveDecays_TuneCP5_13TeV-powhegV2-madspin-pythia8/RunIIFall17MiniAODv2-PU2017_12Apr2018_new_pmx_94X_mc2017_realistic_v14-v1/MINIAODSIM")
+ST_tchannel_top_5f_pow_F17_94X                  = Sample("ST_tchannel_top_5f_pow_F17_94X",              "/ST_t-channel_top_5f_TuneCP5_13TeV-powheg-pythia8/RunIIFall17MiniAODv2-PU2017_12Apr2018_new_pmx_94X_mc2017_realistic_v14-v1/MINIAODSIM")
+ST_tW_antitop_5f_NoFullyHad_pow_PS_F17_94X      = Sample("ST_tW_antitop_5f_NoFullyHad_pow_PS_F17_94X",  "/ST_tW_antitop_5f_NoFullyHadronicDecays_TuneCP5_PSweights_13TeV-powheg-pythia8/RunIIFall17MiniAODv2-PU2017_12Apr2018_94X_mc2017_realistic_v14-v2/MINIAODSIM")
+ST_tW_antitop_5f_incl_pow_F17_94X               = Sample("ST_tW_antitop_5f_incl_pow_F17_94X",           "/ST_tW_antitop_5f_inclusiveDecays_TuneCP5_13TeV-powheg-pythia8/RunIIFall17MiniAODv2-PU2017_12Apr2018_94X_mc2017_realistic_v14-v2/MINIAODSIM")
+ST_tW_antitop_5f_incl_pow_PS_F17_94X            = Sample("ST_tW_antitop_5f_incl_pow_PS_F17_94X",        "/ST_tW_antitop_5f_inclusiveDecays_TuneCP5_PSweights_13TeV-powheg-pythia8/RunIIFall17MiniAODv2-PU2017_12Apr2018_94X_mc2017_realistic_v14-v2/MINIAODSIM")
+ST_tW_top_5f_NoFullyHad_pow_F17_94X             = Sample("ST_tW_top_5f_NoFullyHad_pow_F17_94X",         "/ST_tW_top_5f_NoFullyHadronicDecays_TuneCP5_13TeV-powheg-pythia8/RunIIFall17MiniAODv2-PU2017_12Apr2018_new_pmx_94X_mc2017_realistic_v14-v1/MINIAODSIM")
+ST_tW_top_5f_NoFullyHad_pow_PS_F17_94X          = Sample("ST_tW_top_5f_NoFullyHad_pow_PS_F17_94X",      "/ST_tW_top_5f_NoFullyHadronicDecays_TuneCP5_PSweights_13TeV-powheg-pythia8/RunIIFall17MiniAODv2-PU2017_12Apr2018_new_pmx_94X_mc2017_realistic_v14-v1/MINIAODSIM")
+ST_tW_top_5f_incl_pow_F17_94X                   = Sample("ST_tW_top_5f_incl_pow_F17_94X",               "/ST_tW_top_5f_inclusiveDecays_TuneCP5_13TeV-powheg-pythia8/RunIIFall17MiniAODv2-PU2017_12Apr2018_94X_mc2017_realistic_v14-v2/MINIAODSIM")
+ST_tW_top_5f_incl_pow_PS_F17_94X                = Sample("ST_tW_top_5f_incl_pow_PS_F17_94X",            "/ST_tW_top_5f_inclusiveDecays_TuneCP5_PSweights_13TeV-powheg-pythia8/RunIIFall17MiniAODv2-PU2017_12Apr2018_new_pmx_94X_mc2017_realistic_v14-v1/MINIAODSIM")
 
-TTTo2L2Nu_pow_F17_94X           = Sample("TTTo2L2Nu_pow_F17_94X",           "/TTTo2L2Nu_TuneCP5_13TeV-powheg-pythia8/RunIIFall17MiniAODv2-PU2017_12Apr2018_new_pmx_94X_mc2017_realistic_v14-v1/MINIAODSIM")
-TTTo2L2Nu_pow_PS_F17_94X        = Sample("TTTo2L2Nu_pow_PS_F17_94X",        "/TTTo2L2Nu_TuneCP5_PSweights_13TeV-powheg-pythia8/RunIIFall17MiniAODv2-PU2017_12Apr2018_94X_mc2017_realistic_v14-v1/MINIAODSIM")
-ST_tW_antitop_pow_F17_94X       = Sample("ST_tW_antitop_pow_F17_94X",       "/ST_tW_antitop_5f_inclusiveDecays_TuneCP5_13TeV-powheg-pythia8/RunIIFall17MiniAODv2-PU2017_12Apr2018_94X_mc2017_realistic_v14-v2/MINIAODSIM")
-ST_tW_top_pow_F17_94X           = Sample("ST_tW_top_pow_F17_94X",           "/ST_tW_top_5f_inclusiveDecays_TuneCP5_13TeV-powheg-pythia8/RunIIFall17MiniAODv2-PU2017_12Apr2018_94X_mc2017_realistic_v14-v2/MINIAODSIM")
-ST_schannel_amc_F17_94X         = Sample("ST_schannel_amc_F17_94X",         "/ST_s-channel_4f_leptonDecays_TuneCP5_PSweights_13TeV-amcatnlo-pythia8/RunIIFall17MiniAODv2-PU2017_12Apr2018_new_pmx_94X_mc2017_realistic_v14-v1/MINIAODSIM")
-ST_tchannel_antitop_pow_F17_94X = Sample("ST_tchannel_antitop_pow_F17_94X", "/ST_t-channel_antitop_5f_TuneCP5_PSweights_13TeV-powheg-pythia8/RunIIFall17MiniAODv2-PU2017_12Apr2018_new_pmx_94X_mc2017_realistic_v14-v1/MINIAODSIM")
-ST_tchannel_top_pow_F17_94X     = Sample("ST_tchannel_top_pow_F17_94X",     "/ST_t-channel_top_5f_TuneCP5_13TeV-powheg-pythia8/RunIIFall17MiniAODv2-PU2017_12Apr2018_new_pmx_94X_mc2017_realistic_v14-v1/MINIAODSIM")
+# t(t)g(g)
+TGJets_amc_F17_94X                              = Sample("TGJets_amc_F17_94X",                  "/TGJets_TuneCP5_13TeV_amcatnlo_madspin_pythia8/RunIIFall17MiniAODv2-PU2017_12Apr2018_94X_mc2017_realistic_v14-v2/MINIAODSIM")
+TGJets_lep_amc_PS_F17_94X                       = Sample("TGJets_lep_amc_PS_F17_94X",           "/TGJets_leptonDecays_TuneCP5_PSweights_13TeV-amcatnlo-pythia8/RunIIFall17MiniAODv2-PU2017_12Apr2018_94X_mc2017_realistic_v14-v1/MINIAODSIM")
+TTGG_0Jets_amc_F17_94X                          = Sample("TTGG_0Jets_amc_F17_94X",              "/TTGG_0Jets_TuneCP5_13TeV_amcatnlo_madspin_pythia8/RunIIFall17MiniAODv2-PU2017_12Apr2018_94X_mc2017_realistic_v14-v2/MINIAODSIM")
+TTGJets_amc_F17_94X                             = Sample("TTGJets_amc_F17_94X",                 "/TTGJets_TuneCP5_13TeV-amcatnloFXFX-madspin-pythia8/RunIIFall17MiniAODv2-PU2017_12Apr2018_new_pmx_94X_mc2017_realistic_v14-v1/MINIAODSIM")
+TTGamma_dilep_F17_94X                           = Sample("TTGamma_dilep_F17_94X",               "/TTGamma_Dilept_TuneCP5_PSweights_13TeV_madgraph_pythia8/RunIIFall17MiniAODv2-PU2017_12Apr2018_94X_mc2017_realistic_v14-v1/MINIAODSIM")
+TTGamma_had_F17_94X                             = Sample("TTGamma_had_F17_94X",                 "/TTGamma_Hadronic_TuneCP5_PSweights_13TeV_madgraph_pythia8/RunIIFall17MiniAODv2-PU2017_12Apr2018_94X_mc2017_realistic_v14-v1/MINIAODSIM")
+TTGamma_semilepFromT_F17_94X                    = Sample("TTGamma_semilepFromT_F17_94X",        "/TTGamma_SingleLeptFromT_TuneCP5_PSweights_13TeV_madgraph_pythia8/RunIIFall17MiniAODv2-PU2017_12Apr2018_94X_mc2017_realistic_v14-v1/MINIAODSIM")
+TTGamma_semilepFromTbar_F17_94X                 = Sample("TTGamma_semilepFromTbar_F17_94X ",    "/TTGamma_SingleLeptFromTbar_TuneCP5_PSweights_13TeV_madgraph_pythia8/RunIIFall17MiniAODv2-PU2017_12Apr2018_94X_mc2017_realistic_v14-v1/MINIAODSIM")
 
+TTJets_FXFX_F17_94X                             = Sample("TTJets_FXFX_F17_94X",                 "/TTJets_TuneCP5_13TeV-amcatnloFXFX-pythia8/RunIIFall17MiniAODv2-PU2017_12Apr2018_new_pmx_94X_mc2017_realistic_v14-v1/MINIAODSIM")
+TTJets_MLM_F17_94X                              = Sample("TTJets_MLM_F17_94X",                  "/TTJets_TuneCP5_13TeV-madgraphMLM-pythia8/RunIIFall17MiniAODv2-PU2017_12Apr2018_94X_mc2017_realistic_v14-v1/MINIAODSIM")
+TTJets_semilepFromT_MLM_F17_94X                 = Sample("TTJets_semilepFromT_MLM_F17_94X",     "/TTJets_SingleLeptFromT_TuneCP5_13TeV-madgraphMLM-pythia8/RunIIFall17MiniAODv2-PU2017_12Apr2018_94X_mc2017_realistic_v14-v1/MINIAODSIM")
+TTJets_semilepFromTbar_MLM_F17_94X              = Sample("TTJets_semilepFromTbar_MLM_F17_94X",  "/TTJets_SingleLeptFromTbar_TuneCP5_13TeV-madgraphMLM-pythia8/RunIIFall17MiniAODv2-PU2017_12Apr2018_94X_mc2017_realistic_v14-v1/MINIAODSIM")
+TTJets_dilep_MLM_F17_94X                        = Sample("TTJets_dilep_MLM_F17_94X",            "/TTJets_DiLept_TuneCP5_13TeV-madgraphMLM-pythia8/RunIIFall17MiniAODv2-PU2017_12Apr2018_94X_mc2017_realistic_v14-v1/MINIAODSIM")
 
-top = [
+TTJets_semilepFromT_genMET150_MLM_F17_94X       = Sample("TTJets_semilepFromT_genMET150_MLM_F17_94X",     "/TTJets_SingleLeptFromT_genMET-150_TuneCP5_13TeV-madgraphMLM-pythia8/RunIIFall17MiniAODv2-PU2017_12Apr2018_94X_mc2017_realistic_v14-v1/MINIAODSIM")
+TTJets_semilepFromTbar_genMET150_MLM_F17_94X    = Sample("TTJets_semilepFromTbar_genMET150_MLM_F17_94X",  "/TTJets_SingleLeptFromTbar_genMET-150_TuneCP5_13TeV-madgraphMLM-pythia8/RunIIFall17MiniAODv2-PU2017_12Apr2018_94X_mc2017_realistic_v14-v2/MINIAODSIM")
+TTJets_dilep_genMET150_MLM_F17_94X              = Sample("TTJets_dilep_genMET150_MLM_F17_94X",            "/TTJets_DiLept_genMET-150_TuneCP5_13TeV-madgraphMLM-pythia8/RunIIFall17MiniAODv2-PU2017_12Apr2018_94X_mc2017_realistic_v14-v1/MINIAODSIM")
+
+TTJets_HT600to800_F17_94X                       = Sample("TTJets_HT600to800_F17_94X",           "/TTJets_HT-600to800_TuneCP5_13TeV-madgraphMLM-pythia8/RunIIFall17MiniAODv2-PU2017_12Apr2018_94X_mc2017_realistic_v14-v1/MINIAODSIM")
+TTJets_HT600to800_F17_94X                       = Sample("TTJets_HT600to800_F17_94X",           "/TTJets_HT-800to1200_TuneCP5_13TeV-madgraphMLM-pythia8/RunIIFall17MiniAODv2-PU2017_12Apr2018_94X_mc2017_realistic_v14-v1/MINIAODSIM")
+TTJets_HT600to800_F17_94X                       = Sample("TTJets_HT600to800_F17_94X",           "/TTJets_HT-1200to2500_TuneCP5_13TeV-madgraphMLM-pythia8/RunIIFall17MiniAODv2-PU2017_12Apr2018_94X_mc2017_realistic_v14-v1/MINIAODSIM")
+TTJets_HT600to800_F17_94X                       = Sample("TTJets_HT600to800_F17_94X",           "/TTJets_HT-2500toInf_TuneCP5_13TeV-madgraphMLM-pythia8/RunIIFall17MiniAODv2-PU2017_12Apr2018_94X_mc2017_realistic_v14-v3/MINIAODSIM")
+TTTo2L2Nu_pow_F17_94X                           = Sample("TTTo2L2Nu_pow_F17_94X",               "/TTTo2L2Nu_TuneCP5_13TeV-powheg-pythia8/RunIIFall17MiniAODv2-PU2017_12Apr2018_new_pmx_94X_mc2017_realistic_v14-v1/MINIAODSIM")
+TTTo2L2Nu_pow_PS_F17_94X                        = Sample("TTTo2L2Nu_pow_PS_F17_94X",            "/TTTo2L2Nu_TuneCP5_PSweights_13TeV-powheg-pythia8/RunIIFall17MiniAODv2-PU2017_12Apr2018_new_pmx_94X_mc2017_realistic_v14-v2/MINIAODSIM")
+TTToHadronic_pow_F17_94X                        = Sample("TTToHadronic_pow_F17_94X",            "/TTToHadronic_TuneCP5_13TeV-powheg-pythia8/RunIIFall17MiniAODv2-PU2017_12Apr2018_new_pmx_94X_mc2017_realistic_v14-v2/MINIAODSIM")
+TTToHadronic_pow_PS_F17_94X                     = Sample("TTToHadronic_pow_PS_F17_94X",         "/TTToHadronic_TuneCP5_PSweights_13TeV-powheg-pythia8/RunIIFall17MiniAODv2-PU2017_12Apr2018_new_pmx_94X_mc2017_realistic_v14-v1/MINIAODSIM")
+TTToSemiLeptonic_pow_F17_94X                    = Sample("TTToSemiLeptonic_pow_F17_94X",        "/TTToSemiLeptonic_TuneCP5_13TeV-powheg-pythia8/RunIIFall17MiniAODv2-PU2017_12Apr2018_new_pmx_94X_mc2017_realistic_v14-v1/MINIAODSIM")
+TTToSemiLeptonic_pow_PS_F17_94X                 = Sample("TTToSemiLeptonic_pow_PS_F17_94X",     "/TTToSemiLeptonic_TuneCP5_PSweights_13TeV-powheg-pythia8/RunIIFall17MiniAODv2-PU2017_12Apr2018_94X_mc2017_realistic_v14-v2/MINIAODSIM")
+
+TTTJ_F17_94X                                    = Sample("TTTJ_F17_94X",                        "/TTTJ_TuneCP5_13TeV-madgraph-pythia8/RunIIFall17MiniAODv2-PU2017_12Apr2018_new_pmx_94X_mc2017_realistic_v14-v2/MINIAODSIM")
+TTTT_amc_F17_94X                                = Sample("TTTT_amc_F17_94X",                    "/TTTT_TuneCP5_13TeV-amcatnlo-pythia8/RunIIFall17MiniAODv2-PU2017_12Apr2018_94X_mc2017_realistic_v14-v1/MINIAODSIM")
+TTTT_amc_PS_F17_94X                             = Sample("TTTT_amc_PS_F17_94X",                 "/TTTT_TuneCP5_PSweights_13TeV-amcatnlo-pythia8/RunIIFall17MiniAODv2-PU2017_12Apr2018_94X_mc2017_realistic_v14-v1/MINIAODSIM")
+TTTW_F17_94X                                    = Sample("TTTW_F17_94X",                        "/TTTW_TuneCP5_13TeV-madgraph-pythia8/RunIIFall17MiniAODv2-PU2017_12Apr2018_new_pmx_94X_mc2017_realistic_v14-v2/MINIAODSIM")
+TTWJetsToLNu_FXFX_F17_94X                       = Sample("TTWJetsToLNu_FXFX_F17_94X",           "/TTWJetsToLNu_TuneCP5_13TeV-amcatnloFXFX-madspin-pythia8/RunIIFall17MiniAODv2-PU2017_12Apr2018_94X_mc2017_realistic_v14-v1/MINIAODSIM")
+TTWJetsToLNu_FXFX_PS_F17_94X                    = Sample("TTWJetsToLNu_FXFX_PS_F17_94X ",       "/TTWJetsToLNu_TuneCP5_PSweights_13TeV-amcatnloFXFX-madspin-pythia8/RunIIFall17MiniAODv2-PU2017_12Apr2018_new_pmx_94X_mc2017_realistic_v14-v1/MINIAODSIM")
+TTWJetsToQQ_FXFX_F17_94X                        = Sample("TTWJetsToQQ_FXFX_F17_94X",            "/TTWJetsToQQ_TuneCP5_13TeV-amcatnloFXFX-madspin-pythia8/RunIIFall17MiniAODv2-PU2017_12Apr2018_94X_mc2017_realistic_v14-v2/MINIAODSIM")
+TTWJets_MLM_F17_94X                             = Sample("TTWJets_MLM_F17_94X",                 "/ttWJets_TuneCP5_13TeV_madgraphMLM_pythia8/RunIIFall17MiniAODv2-PU2017_12Apr2018_94X_mc2017_realistic_v14-v1/MINIAODSIM")
+TTWJets_MLM_F17_94X_ext1                        = Sample("TTWJets_MLM_F17_94X_ext1",            "/ttWJets_TuneCP5_13TeV_madgraphMLM_pythia8/RunIIFall17MiniAODv2-PU2017_12Apr2018_94X_mc2017_realistic_v14_ext1-v2/MINIAODSIM")
+TTZToLLNuNu_M10_amc_F17_94X                     = Sample("TTZToLLNuNu_M10_amc_F17_94X",         "/TTZToLLNuNu_M-10_TuneCP5_13TeV-amcatnlo-pythia8/RunIIFall17MiniAODv2-PU2017_12Apr2018_94X_mc2017_realistic_v14-v1/MINIAODSIM")
+TTZToLL_M1to10_amc_F17_94X                      = Sample("TTZToLL_M1to10_amc_F17_94X",          "/TTZToLL_M-1to10_TuneCP5_13TeV-amcatnlo-pythia8/RunIIFall17MiniAODv2-PU2017_12Apr2018_94X_mc2017_realistic_v14-v1/MINIAODSIM")
+TTZToQQ_amc_F17_94X                             = Sample("TTZToQQ_amc_F17_94X",                 "/TTZToQQ_TuneCP5_13TeV-amcatnlo-pythia8/RunIIFall17MiniAODv2-PU2017_12Apr2018_94X_mc2017_realistic_v14-v2/MINIAODSIM")
+TTZJets_MLM_F17_94X                             = Sample("TTZJets_MLM_F17_94X",                 "/ttZJets_TuneCP5_13TeV_madgraphMLM_pythia8/RunIIFall17MiniAODv2-PU2017_12Apr2018_94X_mc2017_realistic_v14-v1/MINIAODSIM")
+TTZJets_MLM_F17_94X_ext1                        = Sample("TTZJets_MLM_F17_94X_ext1",            "/ttZJets_TuneCP5_13TeV_madgraphMLM_pythia8/RunIIFall17MiniAODv2-PU2017_12Apr2018_94X_mc2017_realistic_v14_ext1-v3/MINIAODSIM")
+TZQ_Zhad_Wlept_4f_amc_F17_94X                   = Sample("TZQ_Zhad_Wlept_4f_amc_F17_94X",       "/tZq_Zhad_Wlept_4f_ckm_NLO_TuneCP5_PSweights_13TeV-amcatnlo-pythia8/RunIIFall17MiniAODv2-PU2017_12Apr2018_94X_mc2017_realistic_v14-v1/MINIAODSIM")
+TZQ_ll_4f_amc_F17_94X                           = Sample("TZQ_ll_4f_amc_F17_94X ",              "/tZq_ll_4f_ckm_NLO_TuneCP5_PSweights_13TeV-amcatnlo-pythia8/RunIIFall17MiniAODv2-PU2017_12Apr2018_new_pmx_94X_mc2017_realistic_v14-v2/MINIAODSIM")
+TZQ_nunu_4f_amc_F17_94X                         = Sample("TZQ_nunu_4f_amc_F17_94X",             "/tZq_nunu_4f_ckm_NLO_TuneCP5_PSweights_13TeV-madgraph-pythia8/RunIIFall17MiniAODv2-PU2017_12Apr2018_94X_mc2017_realistic_v14-v2/MINIAODSIM")
+ttHToNonbb_pow_F17_94X                          = Sample("ttHToNonbb_pow_F17_94X",              "/ttHToNonbb_M125_TuneCP5_13TeV-powheg-pythia8/RunIIFall17MiniAODv2-PU2017_12Apr2018_new_pmx_94X_mc2017_realistic_v14-v1/MINIAODSIM")
+ttHTobb_pow_F17_94X                             = Sample("ttHTobb_pow_F17_94X",                 "/ttHTobb_M125_TuneCP5_13TeV-powheg-pythia8/RunIIFall17MiniAODv2-PU2017_12Apr2018_new_pmx_94X_mc2017_realistic_v14-v1/MINIAODSIM")
+ttH_pow_F17_94X                                 = Sample("ttH_pow_F17_94X",                     "/ttH_M125_TuneCP5_13TeV-powheg-pythia8/RunIIFall17MiniAODv2-PU2017_12Apr2018_94X_mc2017_realistic_v14-v1/MINIAODSIM")
+TTHH_F17_94X                                    = Sample("TTHH_F17_94X",                        "/TTHH_TuneCP5_13TeV-madgraph-pythia8/RunIIFall17MiniAODv2-PU2017_12Apr2018_new_pmx_94X_mc2017_realistic_v14-v1/MINIAODSIM")
+TTHH_F17_94X                                    = Sample("TTHH_F17_94X",                        "/TTZH_TuneCP5_13TeV-madgraph-pythia8/RunIIFall17MiniAODv2-PU2017_12Apr2018_new_pmx_94X_mc2017_realistic_v14-v1/MINIAODSIM")
+TTWH_F17_94X                                    = Sample("TTWH_F17_94X",                        "/TTWH_TuneCP5_13TeV-madgraph-pythia8/RunIIFall17MiniAODv2-PU2017_12Apr2018_new_pmx_94X_mc2017_realistic_v14-v1/MINIAODSIM")
+TTWW_F17_94X                                    = Sample("TTWW_F17_94X",                        "/TTWW_TuneCP5_13TeV-madgraph-pythia8/RunIIFall17MiniAODv2-PU2017_12Apr2018_new_pmx_94X_mc2017_realistic_v14_ext1-v1/MINIAODSIM")
+TTWZ_F17_94X                                    = Sample("TTWZ_F17_94X",                        "/TTWZ_TuneCP5_13TeV-madgraph-pythia8/RunIIFall17MiniAODv2-PU2017_12Apr2018_new_pmx_94X_mc2017_realistic_v14-v1/MINIAODSIM")
+TTZZ_F17_94X                                    = Sample("TTZZ_F17_94X",                        "/TTZZ_TuneCP5_13TeV-madgraph-pythia8/RunIIFall17MiniAODv2-PU2017_12Apr2018_new_pmx_94X_mc2017_realistic_v14-v1/MINIAODSIM")
+
+top=[
+    ST_schannel_4f_amc_F17_94X,
+    ST_schannel_4f_amc_PS_F17_94X,
+    ST_tchannel_antitop_4f_incl_pow_F17_94X,
+    ST_tchannel_antitop_5f_pow_PS_F17_94X,
+    ST_tchannel_top_4f_incl_pow_F17_94X,
+    ST_tchannel_top_5f_pow_F17_94X,
+    ST_tW_antitop_5f_NoFullyHad_pow_PS_F17_94X,
+    ST_tW_antitop_5f_incl_pow_F17_94X,
+    ST_tW_antitop_5f_incl_pow_PS_F17_94X,
+    ST_tW_top_5f_NoFullyHad_pow_F17_94X,
+    ST_tW_top_5f_NoFullyHad_pow_PS_F17_94X,
+    ST_tW_top_5f_incl_pow_F17_94X,
+    ST_tW_top_5f_incl_pow_PS_F17_94X,
+    TGJets_amc_F17_94X,
+    TGJets_lep_amc_PS_F17_94X,
+    TTGG_0Jets_amc_F17_94X,
+    TTGJets_amc_F17_94X,
+    TTGamma_dilep_F17_94X,
+    TTGamma_had_F17_94X,
+    TTGamma_semilepFromT_F17_94X,
+    TTGamma_semilepFromTbar_F17_94X,
+    TTJets_FXFX_F17_94X,
+    TTJets_MLM_F17_94X,
+    TTJets_semilepFromT_MLM_F17_94X,
+    TTJets_semilepFromTbar_MLM_F17_94X,
+    TTJets_dilep_MLM_F17_94X,
+    TTJets_semilepFromT_genMET150_MLM_F17_94X,
+    TTJets_semilepFromTbar_genMET150_MLM_F17_94X,
+    TTJets_dilep_genMET150_MLM_F17_94X,
+    TTJets_HT600to800_F17_94X,
+    TTJets_HT600to800_F17_94X,
+    TTJets_HT600to800_F17_94X,
+    TTJets_HT600to800_F17_94X,
     TTTo2L2Nu_pow_F17_94X,
     TTTo2L2Nu_pow_PS_F17_94X,
-    ST_tW_antitop_pow_F17_94X,
-    ST_tW_top_pow_F17_94X,
-    ST_schannel_amc_F17_94X,
-    ST_tchannel_antitop_pow_F17_94X,
-    ST_tchannel_top_pow_F17_94X,
+    TTToHadronic_pow_F17_94X,
+    TTToHadronic_pow_PS_F17_94X,
+    TTToSemiLeptonic_pow_F17_94X,
+    TTToSemiLeptonic_pow_PS_F17_94X,
+    TTTJ_F17_94X,
+    TTTT_amc_F17_94X,
+    TTTT_amc_PS_F17_94X,
+    TTTW_F17_94X,
+    TTWJetsToLNu_FXFX_F17_94X,
+    TTWJetsToLNu_FXFX_PS_F17_94X,
+    TTWJetsToQQ_FXFX_F17_94X,
+    TTWJets_MLM_F17_94X,
+    TTWJets_MLM_F17_94X_ext1,
+    TTZToLLNuNu_M10_amc_F17_94X,
+    TTZToLL_M1to10_amc_F17_94X,
+    TTZToQQ_amc_F17_94X,
+    TTZJets_MLM_F17_94X,
+    TTZJets_MLM_F17_94X_ext1,
+    TZQ_Zhad_Wlept_4f_amc_F17_94X,
+    TZQ_ll_4f_amc_F17_94X,
+    TZQ_nunu_4f_amc_F17_94X,
+    ttHToNonbb_pow_F17_94X,
+    ttHTobb_pow_F17_94X,
+    ttH_pow_F17_94X,
+    TTHH_F17_94X,
+    TTHH_F17_94X,
+    TTWH_F17_94X,
+    TTWW_F17_94X,
+    TTWZ_F17_94X,
+    TTZZ_F17_94X,
 ]
 
 
+WJetsToLNu_HT100to200_F17_94X                   = Sample("WJetsToLNu_HT100to200_F17_94X",       "/WJetsToLNu_HT-100To200_TuneCP5_13TeV-madgraphMLM-pythia8/RunIIFall17MiniAODv2-PU2017_12Apr2018_94X_mc2017_realistic_v14-v2/MINIAODSIM")
+WJetsToLNu_HT200to400_F17_94X                   = Sample("WJetsToLNu_HT200to400_F17_94X",       "/WJetsToLNu_HT-200To400_TuneCP5_13TeV-madgraphMLM-pythia8/RunIIFall17MiniAODv2-PU2017_12Apr2018_94X_mc2017_realistic_v14-v1/MINIAODSIM")
+WJetsToLNu_HT400to600_F17_94X                   = Sample("WJetsToLNu_HT400to600_F17_94X",       "/WJetsToLNu_HT-400To600_TuneCP5_13TeV-madgraphMLM-pythia8/RunIIFall17MiniAODv2-PU2017_12Apr2018_94X_mc2017_realistic_v14-v1/MINIAODSIM")
+WJetsToLNu_HT600to800_F17_94X                   = Sample("WJetsToLNu_HT600to800_F17_94X",       "/WJetsToLNu_HT-600To800_TuneCP5_13TeV-madgraphMLM-pythia8/RunIIFall17MiniAODv2-PU2017_12Apr2018_94X_mc2017_realistic_v14-v1/MINIAODSIM")
+WJetsToLNu_HT800to1200_F17_94X                  = Sample("WJetsToLNu_HT800to1200_F17_94X",      "/WJetsToLNu_HT-800To1200_TuneCP5_13TeV-madgraphMLM-pythia8/RunIIFall17MiniAODv2-PU2017_12Apr2018_94X_mc2017_realistic_v14-v1/MINIAODSIM")
+WJetsToLNu_HT1200to2500_F17_94X                 = Sample("WJetsToLNu_HT1200to2500_F17_94X",     "/WJetsToLNu_HT-1200To2500_TuneCP5_13TeV-madgraphMLM-pythia8/RunIIFall17MiniAODv2-PU2017_12Apr2018_94X_mc2017_realistic_v14-v1/MINIAODSIM")
+WJetsToLNu_HT2500toInf_F17_94X                  = Sample("WJetsToLNu_HT2500toInf_F17_94X",      "/WJetsToLNu_HT-2500ToInf_TuneCP5_13TeV-madgraphMLM-pythia8/RunIIFall17MiniAODv2-PU2017_12Apr2018_94X_mc2017_realistic_v14-v3/MINIAODSIM")
+WJetsToLNu_MLM_F17_94X                          = Sample("WJetsToLNu_MLM_F17_94X",              "/WJetsToLNu_TuneCP5_13TeV-madgraphMLM-pythia8/RunIIFall17MiniAODv2-PU2017_12Apr2018_94X_mc2017_realistic_v14-v2/MINIAODSIM")
+WJetsToLNu_MLM_F17_94X_ext1                     = Sample("WJetsToLNu_MLM_F17_94X_ext1",         "/WJetsToLNu_TuneCP5_13TeV-madgraphMLM-pythia8/RunIIFall17MiniAODv2-PU2017_12Apr2018_94X_mc2017_realistic_v14_ext1-v2/MINIAODSIM")
 
-WW_F17_94X      = Sample("WW_F17_94X",      "/WW_TuneCP5_13TeV-pythia8/RunIIFall17MiniAODv2-PU2017_12Apr2018_94X_mc2017_realistic_v14-v1/MINIAODSIM")
-WZ_F17_94X      = Sample("WZ_F17_94X",      "/WZ_TuneCP5_13TeV-pythia8/RunIIFall17MiniAODv2-PU2017_12Apr2018_94X_mc2017_realistic_v14-v1/MINIAODSIM")
-ZZ_F17_94X      = Sample("ZZ_F17_94X",      "/ZZ_TuneCP5_13TeV-pythia8/RunIIFall17MiniAODv2-PU2017_12Apr2018_94X_mc2017_realistic_v14-v1/MINIAODSIM")
+WJets = [
+    WJetsToLNu_HT100to200_F17_94X,
+    WJetsToLNu_HT200to400_F17_94X,
+    WJetsToLNu_HT400to600_F17_94X,
+    WJetsToLNu_HT600to800_F17_94X,
+    WJetsToLNu_HT800to1200_F17_94X,
+    WJetsToLNu_HT1200to2500_F17_94X,
+    WJetsToLNu_HT2500toInf_F17_94X,
+    WJetsToLNu_MLM_F17_94X,
+    WJetsToLNu_MLM_F17_94X_ext1,
+]
 
-multiboson = [
+WW_DoubleScattering_F17_94X                     = Sample("WW_DoubleScattering_F17_94X",         "/WW_DoubleScattering_13TeV-pythia8_TuneCP5/RunIIFall17MiniAODv2-PU2017_12Apr2018_94X_mc2017_realistic_v14-v1/MINIAODSIM")
+WW_F17_94X                                      = Sample("WW_F17_94X",                          "/WW_TuneCP5_13TeV-pythia8/RunIIFall17MiniAODv2-PU2017_12Apr2018_94X_mc2017_realistic_v14-v1/MINIAODSIM")
+WZ_F17_94X                                      = Sample("WZ_F17_94X",                          "/WZ_TuneCP5_13TeV-pythia8/RunIIFall17MiniAODv2-PU2017_12Apr2018_94X_mc2017_realistic_v14-v1/MINIAODSIM")
+ZZ_F17_94X                                      = Sample("ZZ_F17_94X",                          "/ZZ_TuneCP5_13TeV-pythia8/RunIIFall17MiniAODv2-PU2017_12Apr2018_94X_mc2017_realistic_v14-v1/MINIAODSIM")
+WWTo2L2Nu_pow_PS_F17_94X                        = Sample("WWTo2L2Nu_pow_PS_F17_94X",            "/WWTo2L2Nu_NNPDF31_TuneCP5_PSweights_13TeV-powheg-pythia8/RunIIFall17MiniAODv2-PU2017_12Apr2018_94X_mc2017_realistic_v14_ext1-v1/MINIAODSIM")
+WWToLNuQQ_pow_PS_F17_94X                        = Sample("WWToLNuQQ_pow_PS_F17_94X",            "/WWToLNuQQ_NNPDF31_TuneCP5_PSweights_13TeV-powheg-pythia8/RunIIFall17MiniAODv2-PU2017_12Apr2018_94X_mc2017_realistic_v14_ext1-v1/MINIAODSIM")
+WZTo3LNu_FXFX_F17_94X                           = Sample("WZTo3LNu_FXFX_F17_94X",               "/WZTo3LNu_TuneCP5_13TeV-amcatnloFXFX-pythia8/RunIIFall17MiniAODv2-PU2017_12Apr2018_new_pmx_94X_mc2017_realistic_v14-v1/MINIAODSIM")
+ZZTo2Q2Nu_FXFX_F17_94X                          = Sample("ZZTo2Q2Nu_FXFX_F17_94X",              "/ZZTo2Q2Nu_TuneCP5_13TeV_amcatnloFXFX_madspin_pythia8/RunIIFall17MiniAODv2-PU2017_12Apr2018_94X_mc2017_realistic_v14-v1/MINIAODSIM")
+
+diboson = [
+    WW_DoubleScattering_F17_94X,
     WW_F17_94X,
     WZ_F17_94X,
     ZZ_F17_94X,
+    WWTo2L2Nu_pow_PS_F17_94X,
+    WWToLNuQQ_pow_PS_F17_94X,
+    WZTo3LNu_FXFX_F17_94X,
+    ZZTo2Q2Nu_FXFX_F17_94X,
 ]
 
-allSamples = DY + top + multiboson
+
+WWW_amc_F17_94X                                 = Sample("WWW_amc_F17_94X",                     "/WWW_4F_TuneCP5_13TeV-amcatnlo-pythia8/RunIIFall17MiniAODv2-PU2017_12Apr2018_94X_mc2017_realistic_v14-v2/MINIAODSIM")
+WWZ_amc_F17_94X                                 = Sample("WWZ_amc_F17_94X",                     "/WWZ_4F_TuneCP5_13TeV-amcatnlo-pythia8/RunIIFall17MiniAODv2-PU2017_12Apr2018_94X_mc2017_realistic_v14-v2/MINIAODSIM")
+WZZ_amc_F17_94X                                 = Sample("WZZ_amc_F17_94X",                     "/WZZ_TuneCP5_13TeV-amcatnlo-pythia8/RunIIFall17MiniAODv2-PU2017_12Apr2018_94X_mc2017_realistic_v14-v1/MINIAODSIM")
+ZZZ_amc_F17_94X                                 = Sample("ZZZ_amc_F17_94X",                     "/ZZZ_TuneCP5_13TeV-amcatnlo-pythia8/RunIIFall17MiniAODv2-PU2017_12Apr2018_94X_mc2017_realistic_v14-v2/MINIAODSIM")
+WWG_amc_F17_94X                                 = Sample("WWG_amc_F17_94X",                     "/WWG_TuneCP5_13TeV-amcatnlo-pythia8/RunIIFall17MiniAODv2-PU2017_12Apr2018_94X_mc2017_realistic_v14-v2/MINIAODSIM")
+WZG_amc_F17_94X                                 = Sample("WZG_amc_F17_94X",                     "/WZG_TuneCP5_13TeV-amcatnlo-pythia8/RunIIFall17MiniAODv2-PU2017_12Apr2018_94X_mc2017_realistic_v14-v1/MINIAODSIM")
+
+multiboson = [
+    WWW_amc_F17_94X,
+    WWZ_amc_F17_94X,
+    WZZ_amc_F17_94X,
+    ZZZ_amc_F17_94X,
+    WWG_amc_F17_94X,
+    WZG_amc_F17_94X,
+]
+
+## sum up
+allSamples = DY + top + WJets + diboson + multiboson
 

--- a/miniAOD/python/Run2017_31Mar2018.py
+++ b/miniAOD/python/Run2017_31Mar2018.py
@@ -1,3 +1,7 @@
+'''
+dasgoclient -query="dataset=/SingleMuon/Run2017*31Mar2018*/MINIAOD"
+'''
+
 from Samples.Tools.Sample import Sample
 
 ## DoubleMuon
@@ -15,6 +19,62 @@ DoubleMuon = [
     DoubleMuon_Run2017F_31Mar2018,
 ]
 
+DoubleEG_Run2017B_31Mar2018   = Sample("DoubleEG_Run2017B_31Mar2018", "/DoubleEG/Run2017B-31Mar2018-v1/MINIAOD")
+DoubleEG_Run2017C_31Mar2018   = Sample("DoubleEG_Run2017C_31Mar2018", "/DoubleEG/Run2017C-31Mar2018-v1/MINIAOD")
+DoubleEG_Run2017D_31Mar2018   = Sample("DoubleEG_Run2017D_31Mar2018", "/DoubleEG/Run2017D-31Mar2018-v1/MINIAOD")
+DoubleEG_Run2017E_31Mar2018   = Sample("DoubleEG_Run2017E_31Mar2018", "/DoubleEG/Run2017E-31Mar2018-v1/MINIAOD")
+DoubleEG_Run2017F_31Mar2018   = Sample("DoubleEG_Run2017F_31Mar2018", "/DoubleEG/Run2017F-31Mar2018-v1/MINIAOD")
+
+DoubleEG = [
+    DoubleEG_Run2017B_31Mar2018,
+    DoubleEG_Run2017C_31Mar2018,
+    DoubleEG_Run2017D_31Mar2018,
+    DoubleEG_Run2017E_31Mar2018,
+    DoubleEG_Run2017F_31Mar2018,
+]
+
+MuonEG_Run2017B_31Mar2018   = Sample("MuonEG_Run2017B_31Mar2018", "/MuonEG/Run2017B-31Mar2018-v1/MINIAOD")
+MuonEG_Run2017C_31Mar2018   = Sample("MuonEG_Run2017C_31Mar2018", "/MuonEG/Run2017C-31Mar2018-v1/MINIAOD")
+MuonEG_Run2017D_31Mar2018   = Sample("MuonEG_Run2017D_31Mar2018", "/MuonEG/Run2017D-31Mar2018-v1/MINIAOD")
+MuonEG_Run2017E_31Mar2018   = Sample("MuonEG_Run2017E_31Mar2018", "/MuonEG/Run2017E-31Mar2018-v1/MINIAOD")
+MuonEG_Run2017F_31Mar2018   = Sample("MuonEG_Run2017F_31Mar2018", "/MuonEG/Run2017F-31Mar2018-v1/MINIAOD")
+
+MuonEG = [
+    MuonEG_Run2017B_31Mar2018,
+    MuonEG_Run2017C_31Mar2018,
+    MuonEG_Run2017D_31Mar2018,
+    MuonEG_Run2017E_31Mar2018,
+    MuonEG_Run2017F_31Mar2018,
+]
+
+SingleMuon_Run2017B_31Mar2018   = Sample("SingleMuon_Run2017B_31Mar2018", "/SingleMuon/Run2017B-31Mar2018-v1/MINIAOD")
+SingleMuon_Run2017C_31Mar2018   = Sample("SingleMuon_Run2017C_31Mar2018", "/SingleMuon/Run2017C-31Mar2018-v1/MINIAOD")
+SingleMuon_Run2017D_31Mar2018   = Sample("SingleMuon_Run2017D_31Mar2018", "/SingleMuon/Run2017D-31Mar2018-v1/MINIAOD")
+SingleMuon_Run2017E_31Mar2018   = Sample("SingleMuon_Run2017E_31Mar2018", "/SingleMuon/Run2017E-31Mar2018-v1/MINIAOD")
+SingleMuon_Run2017F_31Mar2018   = Sample("SingleMuon_Run2017F_31Mar2018", "/SingleMuon/Run2017F-31Mar2018-v1/MINIAOD")
+
+SingleMuon = [
+    SingleMuon_Run2017B_31Mar2018,
+    SingleMuon_Run2017C_31Mar2018,
+    SingleMuon_Run2017D_31Mar2018,
+    SingleMuon_Run2017E_31Mar2018,
+    SingleMuon_Run2017F_31Mar2018,
+]
+
+SingleElectron_Run2017B_31Mar2018   = Sample("SingleElectron_Run2017B_31Mar2018", "/SingleElectron/Run2017B-31Mar2018-v1/MINIAOD")
+SingleElectron_Run2017C_31Mar2018   = Sample("SingleElectron_Run2017C_31Mar2018", "/SingleElectron/Run2017C-31Mar2018-v1/MINIAOD")
+SingleElectron_Run2017D_31Mar2018   = Sample("SingleElectron_Run2017D_31Mar2018", "/SingleElectron/Run2017D-31Mar2018-v1/MINIAOD")
+SingleElectron_Run2017E_31Mar2018   = Sample("SingleElectron_Run2017E_31Mar2018", "/SingleElectron/Run2017E-31Mar2018-v1/MINIAOD")
+SingleElectron_Run2017F_31Mar2018   = Sample("SingleElectron_Run2017F_31Mar2018", "/SingleElectron/Run2017F-31Mar2018-v1/MINIAOD")
+
+SingleElectron = [
+    SingleElectron_Run2017B_31Mar2018,
+    SingleElectron_Run2017C_31Mar2018,
+    SingleElectron_Run2017D_31Mar2018,
+    SingleElectron_Run2017E_31Mar2018,
+    SingleElectron_Run2017F_31Mar2018,
+]
+
 ## sum up
-allSamples = DoubleMuon
+allSamples = DoubleMuon + DoubleEG + MuonEG + SingleMuon + SingleElectron
 

--- a/miniAOD/python/Run2018_promptReco.py
+++ b/miniAOD/python/Run2018_promptReco.py
@@ -1,3 +1,8 @@
+'''
+dasgoclient -query="dataset=/*/Run2018*PromptReco*/MINIAOD"
+'''
+
+
 from Samples.Tools.Sample import Sample
 
 
@@ -68,6 +73,29 @@ MuonEG = [
     MuonEG_Run2018D_promptReco_v2,
 ]
 
+SingleMuon_Run2018A_promptReco_v1 = Sample("SingleMuon_Run2018A_promptReco_v1", "/SingleMuon/Run2018A-PromptReco-v1/MINIAOD")
+SingleMuon_Run2018A_promptReco_v2 = Sample("SingleMuon_Run2018A_promptReco_v2", "/SingleMuon/Run2018A-PromptReco-v2/MINIAOD")
+SingleMuon_Run2018A_promptReco_v3 = Sample("SingleMuon_Run2018A_promptReco_v3", "/SingleMuon/Run2018A-PromptReco-v3/MINIAOD")
+SingleMuon_Run2018B_promptReco_v1 = Sample("SingleMuon_Run2018B_promptReco_v1", "/SingleMuon/Run2018B-PromptReco-v1/MINIAOD")
+SingleMuon_Run2018B_promptReco_v2 = Sample("SingleMuon_Run2018B_promptReco_v2", "/SingleMuon/Run2018B-PromptReco-v2/MINIAOD")
+SingleMuon_Run2018C_promptReco_v1 = Sample("SingleMuon_Run2018C_promptReco_v1", "/SingleMuon/Run2018C-PromptReco-v1/MINIAOD")
+SingleMuon_Run2018C_promptReco_v2 = Sample("SingleMuon_Run2018C_promptReco_v2", "/SingleMuon/Run2018C-PromptReco-v2/MINIAOD")
+SingleMuon_Run2018C_promptReco_v3 = Sample("SingleMuon_Run2018C_promptReco_v3", "/SingleMuon/Run2018C-PromptReco-v3/MINIAOD")
+SingleMuon_Run2018D_promptReco_v2 = Sample("SingleMuon_Run2018D_promptReco_v2", "/SingleMuon/Run2018D-PromptReco-v2/MINIAOD")
+
+SingleMuon = [
+    SingleMuon_Run2018A_promptReco_v1,
+    SingleMuon_Run2018A_promptReco_v2,
+    SingleMuon_Run2018A_promptReco_v3,
+    SingleMuon_Run2018B_promptReco_v1,
+    SingleMuon_Run2018B_promptReco_v2,
+    SingleMuon_Run2018C_promptReco_v1,
+    SingleMuon_Run2018C_promptReco_v2,
+    SingleMuon_Run2018C_promptReco_v3,
+    SingleMuon_Run2018D_promptReco_v2,
+]
+
+
 ## sum up
-allSamples = DoubleMuon + MuonEG + EGamma
+allSamples = DoubleMuon + MuonEG + EGamma + SingleMuon
 


### PR DESCRIPTION
Adding the missing miniAOD samples. These include:
- Fall17miniAODv2
- Run2017 single object PDs
- Autumn18 first finalized samples (e.g. DY and ttbar)
- Run2018 prompt reco

Minor fix of crabManager