### PR TITLE
Added Soft 1L Fall17 14Dec2018 NanoAOD samples. Updated ST and WW xsec to NNLO. Added Run2018 MET PD.

### DIFF
--- a/nanoAOD/python/Fall17_14Dec2018.py
+++ b/nanoAOD/python/Fall17_14Dec2018.py
@@ -39,79 +39,114 @@ logger.info("Using db file: %s", dbFile)
 # specify a local directory if you want to create (and afterwards automatically use) a local copy of the sample, otherwise use the grid.
 
 ## DY
-#DYJetsToLL_M50_LO       = Sample.nanoAODfromDAS("DYJetsToLL_M50_LO", "/DYJetsToLL_M-50_TuneCP5_13TeV-madgraphMLM-pythia8/RunIIFall17NanoAOD-PU2017RECOSIMstep_12Apr2018_94X_mc2017_realistic_v14-v1/NANOAODSIM", dbFile=dbFile, redirector=redirector, xSection=2008.*3, overwrite=ov)
+#DYJetsToLL_M50_LO       = Sample.nanoAODfromDAS("DYJetsToLL_M50_LO",      "/DYJetsToLL_M-50_TuneCP5_13TeV-madgraphMLM-pythia8/RunIIFall17NanoAOD-PU2017RECOSIMstep_12Apr2018_94X_mc2017_realistic_v14-v1/NANOAODSIM", dbFile=dbFile, redirector=redirector, xSection=2008.*3, overwrite=ov)
 #DYJetsToLL_M50_LO_ext1  = Sample.nanoAODfromDAS("DYJetsToLL_M50_LO_ext1", "/DYJetsToLL_M-50_TuneCP5_13TeV-madgraphMLM-pythia8/RunIIFall17NanoAOD-PU2017RECOSIMstep_12Apr2018_94X_mc2017_realistic_v14_ext1-v1/NANOAODSIM", dbFile=dbFile, redirector=redirector, xSection=2008.*3, overwrite=ov)
-DYJetsToLL_M50          = Sample.nanoAODfromDAS("DYJetsToLL_M50",         "/DYJetsToLL_M-50_TuneCP5_13TeV-amcatnloFXFX-pythia8/RunIIFall17NanoAODv4-PU2017_12Apr2018_Nano14Dec2018_102X_mc2017_realistic_v6-v1/NANOAODSIM", dbFile=dbFile, redirector=redirector, xSection=2008.*3, overwrite=ov)
-DYJetsToLL_M50_ext1     = Sample.nanoAODfromDAS("DYJetsToLL_M50_ext1",    "/DYJetsToLL_M-50_TuneCP5_13TeV-amcatnloFXFX-pythia8/RunIIFall17NanoAODv4-PU2017_12Apr2018_Nano14Dec2018_new_pmx_102X_mc2017_realistic_v6_ext1-v1/NANOAODSIM", dbFile=dbFile, redirector=redirector, xSection=2008.*3, overwrite=ov)
-DYJetsToLL_M10to50_LO   = Sample.nanoAODfromDAS("DYJetsToLL_M10to50_LO", "/DYJetsToLL_M-10to50_TuneCP5_13TeV-madgraphMLM-pythia8/RunIIFall17NanoAODv4-PU2017_12Apr2018_Nano14Dec2018_102X_mc2017_realistic_v6-v1/NANOAODSIM", dbFile=dbFile, redirector=redirector, xSection=18610, overwrite=ov)
+DYJetsToLL_M50        = Sample.nanoAODfromDAS("DYJetsToLL_M50",        "/DYJetsToLL_M-50_TuneCP5_13TeV-amcatnloFXFX-pythia8/RunIIFall17NanoAODv4-PU2017_12Apr2018_Nano14Dec2018_102X_mc2017_realistic_v6-v1/NANOAODSIM",              dbFile=dbFile, redirector=redirector, xSection=2008.*3, overwrite=ov)
+DYJetsToLL_M50_ext1   = Sample.nanoAODfromDAS("DYJetsToLL_M50_ext1",   "/DYJetsToLL_M-50_TuneCP5_13TeV-amcatnloFXFX-pythia8/RunIIFall17NanoAODv4-PU2017_12Apr2018_Nano14Dec2018_new_pmx_102X_mc2017_realistic_v6_ext1-v1/NANOAODSIM", dbFile=dbFile, redirector=redirector, xSection=2008.*3, overwrite=ov)
+DYJetsToLL_M10to50_LO = Sample.nanoAODfromDAS("DYJetsToLL_M10to50_LO", "/DYJetsToLL_M-10to50_TuneCP5_13TeV-madgraphMLM-pythia8/RunIIFall17NanoAODv4-PU2017_12Apr2018_Nano14Dec2018_102X_mc2017_realistic_v6-v1/NANOAODSIM",           dbFile=dbFile, redirector=redirector, xSection=18610,   overwrite=ov)
 
 DY = [
-#    DYJetsToLL_M50_LO,
-#    DYJetsToLL_M50_LO_ext1,
-    #DYJetsToLL_M5to50_LO,
-    DYJetsToLL_M10to50_LO,
     DYJetsToLL_M50,
     DYJetsToLL_M50_ext1,
+    DYJetsToLL_M10to50_LO,
+#    DYJetsToLL_M50_LO,
+#    DYJetsToLL_M50_LO_ext1,
+#    DYJetsToLL_M5to50_LO,
     ]
 
-DYJetsToLL_M50_HT70to100      =   Sample.nanoAODfromDAS("DYJetsToLL_M50_HT70to100",         "/DYJetsToLL_M-50_HT-70to100_TuneCP5_13TeV-madgraphMLM-pythia8/RunIIFall17NanoAODv4-PU2017_12Apr2018_Nano14Dec2018_102X_mc2017_realistic_v6-v1/NANOAODSIM",         dbFile=dbFile, redirector=redirector, xSection=170.4*1.23, overwrite=ov)
-DYJetsToLL_M50_HT100to200     =   Sample.nanoAODfromDAS("DYJetsToLL_M50_HT100to200",        "/DYJetsToLL_M-50_HT-100to200_TuneCP5_13TeV-madgraphMLM-pythia8/RunIIFall17NanoAODv4-PU2017_12Apr2018_Nano14Dec2018_new_pmx_102X_mc2017_realistic_v6-v1/NANOAODSIM",        dbFile=dbFile, redirector=redirector, xSection=147.4*1.23, overwrite=ov)
-#DYJetsToLL_M50_HT100to200_ext =   Sample.nanoAODfromDAS("DYJetsToLL_M50_HT100to200_ext",    "/DYJetsToLL_M-50_HT-100to200_TuneCP5_13TeV-madgraphMLM-pythia8/RunIIFall17NanoAOD-PU2017_12Apr2018_94X_mc2017_realistic_v14_ext1-v1/NANOAODSIM",   dbFile=dbFile, redirector=redirector, xSection=147.4*1.23, overwrite=ov)
-DYJetsToLL_M50_HT200to400     =   Sample.nanoAODfromDAS("DYJetsToLL_M50_HT200to400",        "/DYJetsToLL_M-50_HT-200to400_TuneCP5_13TeV-madgraphMLM-pythia8/RunIIFall17NanoAODv4-PU2017_12Apr2018_Nano14Dec2018_102X_mc2017_realistic_v6-v1/NANOAODSIM",        dbFile=dbFile, redirector=redirector, xSection=40.99*1.23, overwrite=ov)
-#DYJetsToLL_M50_HT200to400_ext =   Sample.nanoAODfromDAS("DYJetsToLL_M50_HT200to400_ext",    "/DYJetsToLL_M-50_HT-200to400_TuneCP5_13TeV-madgraphMLM-pythia8/RunIIFall17NanoAOD-PU2017_12Apr2018_94X_mc2017_realistic_v14_ext1-v1/NANOAODSIM",   dbFile=dbFile, redirector=redirector, xSection=40.99*1.23, overwrite=ov)
-DYJetsToLL_M50_HT400to600     =   Sample.nanoAODfromDAS("DYJetsToLL_M50_HT400to600",        "/DYJetsToLL_M-50_HT-400to600_TuneCP5_13TeV-madgraphMLM-pythia8/RunIIFall17NanoAODv4-PU2017_12Apr2018_Nano14Dec2018_new_pmx_102X_mc2017_realistic_v6-v1/NANOAODSIM",        dbFile=dbFile, redirector=redirector, xSection=5.678*1.23, overwrite=ov)
-#DYJetsToLL_M50_HT400to600_ext =   Sample.nanoAODfromDAS("DYJetsToLL_M50_HT400to600_ext",    "/DYJetsToLL_M-50_HT-400to600_TuneCP5_13TeV-madgraphMLM-pythia8/RunIIFall17NanoAOD-PU2017_12Apr2018_94X_mc2017_realistic_v14_ext1-v1/NANOAODSIM",   dbFile=dbFile, redirector=redirector, xSection=5.678*1.23, overwrite=ov)
-#DYJetsToLL_M50_HT600to800     =   Sample.nanoAODfromDAS("DYJetsToLL_M50_HT600to800"   ,     "/DYJetsToLL_M-50_HT-600to800_TuneCP5_13TeV-madgraphMLM-pythia8/RunIIFall17NanoAOD-PU2017_12Apr2018_94X_mc2017_realistic_v14-v1/NANOAODSIM",        dbFile=dbFile, redirector=redirector, xSection=1.367*1.23 , overwrite=ov)
-#DYJetsToLL_M50_HT800to1200    =   Sample.nanoAODfromDAS("DYJetsToLL_M50_HT800to1200"  ,     "/DYJetsToLL_M-50_HT-800to1200_TuneCP5_13TeV-madgraphMLM-pythia8/RunIIFall17NanoAOD-PU2017_12Apr2018_94X_mc2017_realistic_v14-v1/NANOAODSIM",       dbFile=dbFile, redirector=redirector, xSection=0.6304*1.23 , overwrite=ov)
-#DYJetsToLL_M50_HT1200to2500   =   Sample.nanoAODfromDAS("DYJetsToLL_M50_HT1200to2500" ,     "/DYJetsToLL_M-50_HT-1200to2500_TuneCP5_13TeV-madgraphMLM-pythia8/RunIIFall17NanoAOD-PU2017_12Apr2018_94X_mc2017_realistic_v14-v1/NANOAODSIM",      dbFile=dbFile, redirector=redirector, xSection=0.1514*1.23 , overwrite=ov)
-#DYJetsToLL_M50_HT2500toInf    =   Sample.nanoAODfromDAS("DYJetsToLL_M50_HT2500toInf"  ,     "/DYJetsToLL_M-50_HT-2500toInf_TuneCP5_13TeV-madgraphMLM-pythia8/RunIIFall17NanoAOD-PU2017_12Apr2018_94X_mc2017_realistic_v14-v1/NANOAODSIM",       dbFile=dbFile, redirector=redirector, xSection=0.003565*1.23 , overwrite=ov)
+# DY HT bins, M_{ll} [50, inf]
+DYJetsToLL_M50_HT70to100      = Sample.nanoAODfromDAS("DYJetsToLL_M50_HT70to100",      "/DYJetsToLL_M-50_HT-70to100_TuneCP5_13TeV-madgraphMLM-pythia8/RunIIFall17NanoAODv4-PU2017_12Apr2018_Nano14Dec2018_102X_mc2017_realistic_v6-v1/NANOAODSIM",           dbFile=dbFile, redirector=redirector, xSection=170.4*1.23,    overwrite=ov)
+DYJetsToLL_M50_HT100to200     = Sample.nanoAODfromDAS("DYJetsToLL_M50_HT100to200",     "/DYJetsToLL_M-50_HT-100to200_TuneCP5_13TeV-madgraphMLM-pythia8/RunIIFall17NanoAODv4-PU2017_12Apr2018_Nano14Dec2018_new_pmx_102X_mc2017_realistic_v6-v1/NANOAODSIM",  dbFile=dbFile, redirector=redirector, xSection=147.4*1.23,    overwrite=ov)
+DYJetsToLL_M50_HT100to200_ext = Sample.nanoAODfromDAS("DYJetsToLL_M50_HT100to200_ext", "/DYJetsToLL_M-50_HT-100to200_TuneCP5_13TeV-madgraphMLM-pythia8/RunIIFall17NanoAODv4-PU2017_12Apr2018_Nano14Dec2018_102X_mc2017_realistic_v6_ext1-v1/NANOAODSIM",    dbFile=dbFile, redirector=redirector, xSection=147.4*1.23,    overwrite=ov)
+DYJetsToLL_M50_HT200to400     = Sample.nanoAODfromDAS("DYJetsToLL_M50_HT200to400",     "/DYJetsToLL_M-50_HT-200to400_TuneCP5_13TeV-madgraphMLM-pythia8/RunIIFall17NanoAODv4-PU2017_12Apr2018_Nano14Dec2018_102X_mc2017_realistic_v6-v1/NANOAODSIM",          dbFile=dbFile, redirector=redirector, xSection=40.99*1.23,    overwrite=ov)
+DYJetsToLL_M50_HT200to400_ext = Sample.nanoAODfromDAS("DYJetsToLL_M50_HT200to400_ext", "/DYJetsToLL_M-50_HT-200to400_TuneCP5_13TeV-madgraphMLM-pythia8/RunIIFall17NanoAODv4-PU2017_12Apr2018_Nano14Dec2018_102X_mc2017_realistic_v6_ext1-v1/NANOAODSIM",     dbFile=dbFile, redirector=redirector, xSection=40.99*1.23,    overwrite=ov)
+DYJetsToLL_M50_HT400to600     = Sample.nanoAODfromDAS("DYJetsToLL_M50_HT400to600",     "/DYJetsToLL_M-50_HT-400to600_TuneCP5_13TeV-madgraphMLM-pythia8/RunIIFall17NanoAODv4-PU2017_12Apr2018_Nano14Dec2018_new_pmx_102X_mc2017_realistic_v6-v1/NANOAODSIM",  dbFile=dbFile, redirector=redirector, xSection=5.678*1.23,    overwrite=ov)
+DYJetsToLL_M50_HT400to600_ext = Sample.nanoAODfromDAS("DYJetsToLL_M50_HT400to600_ext", "/DYJetsToLL_M-50_HT-400to600_TuneCP5_13TeV-madgraphMLM-pythia8/RunIIFall17NanoAODv4-PU2017_12Apr2018_Nano14Dec2018_102X_mc2017_realistic_v6_ext1-v1/NANOAODSIM",     dbFile=dbFile, redirector=redirector, xSection=5.678*1.23,    overwrite=ov)
+DYJetsToLL_M50_HT600to800     = Sample.nanoAODfromDAS("DYJetsToLL_M50_HT600to800",     "/DYJetsToLL_M-50_HT-600to800_TuneCP5_13TeV-madgraphMLM-pythia8/RunIIFall17NanoAODv4-PU2017_12Apr2018_Nano14Dec2018_new_pmx_102X_mc2017_realistic_v6-v1/NANOAODSIM",  dbFile=dbFile, redirector=redirector, xSection=1.367*1.23,    overwrite=ov)
+DYJetsToLL_M50_HT800to1200    = Sample.nanoAODfromDAS("DYJetsToLL_M50_HT800to1200",    "/DYJetsToLL_M-50_HT-800to1200_TuneCP5_13TeV-madgraphMLM-pythia8/RunIIFall17NanoAODv4-PU2017_12Apr2018_Nano14Dec2018_new_pmx_102X_mc2017_realistic_v6-v1/NANOAODSIM", dbFile=dbFile, redirector=redirector, xSection=0.6304*1.23,   overwrite=ov)
+DYJetsToLL_M50_HT1200to2500   = Sample.nanoAODfromDAS("DYJetsToLL_M50_HT1200to2500",   "/DYJetsToLL_M-50_HT-1200to2500_TuneCP5_13TeV-madgraphMLM-pythia8/RunIIFall17NanoAODv4-PU2017_12Apr2018_Nano14Dec2018_102X_mc2017_realistic_v6-v1/NANOAODSIM",        dbFile=dbFile, redirector=redirector, xSection=0.1514*1.23,   overwrite=ov)
+DYJetsToLL_M50_HT2500toInf    = Sample.nanoAODfromDAS("DYJetsToLL_M50_HT2500toInf",    "/DYJetsToLL_M-50_HT-2500toInf_TuneCP5_13TeV-madgraphMLM-pythia8/RunIIFall17NanoAODv4-PU2017_12Apr2018_Nano14Dec2018_new_pmx_102X_mc2017_realistic_v6-v1/NANOAODSIM", dbFile=dbFile, redirector=redirector, xSection=0.003565*1.23, overwrite=ov)
 
 DYJetsM50HT = [
-    DYJetsToLL_M50_HT70to100   , 
+    DYJetsToLL_M50_HT70to100, 
     DYJetsToLL_M50_HT100to200,
-    #DYJetsToLL_M50_HT100to200_ext,
+    DYJetsToLL_M50_HT100to200_ext,
     DYJetsToLL_M50_HT200to400,
-    #DYJetsToLL_M50_HT200to400_ext,
+    DYJetsToLL_M50_HT200to400_ext,
     DYJetsToLL_M50_HT400to600,
-    #DYJetsToLL_M50_HT400to600_ext,
-    #DYJetsToLL_M50_HT600to800  ,
-    #DYJetsToLL_M50_HT800to1200 ,
-    #DYJetsToLL_M50_HT1200to2500,
-    #DYJetsToLL_M50_HT2500toInf ,
-]
+    DYJetsToLL_M50_HT400to600_ext,
+    DYJetsToLL_M50_HT600to800,
+    DYJetsToLL_M50_HT800to1200,
+    DYJetsToLL_M50_HT1200to2500,
+    DYJetsToLL_M50_HT2500toInf,
+    ]
 
-#DYJetsToLL_M4to50_HT70to100      = Sample.nanoAODfromDAS("DYJetsToLL_M4to50_HT70to100"     , "/DYJetsToLL_M-4to50_HT-70to100_TuneCP5_13TeV-madgraphMLM-pythia8/RunIIFall17NanoAOD-PU2017_12Apr2018_94X_mc2017_realistic_v14_ext1-v1/NANOAODSIM", dbFile=dbFile, redirector=redirector, xSection=303.4, overwrite=ov) #LO without 1.23 k-factor
-#DYJetsToLL_M4to50_HT100to200     = Sample.nanoAODfromDAS("DYJetsToLL_M4to50_HT100to200"    , "/DYJetsToLL_M-4to50_HT-100to200_TuneCP5_13TeV-madgraphMLM-pythia8/RunIIFall17NanoAOD-PU2017_12Apr2018_94X_mc2017_realistic_v14-v1/NANOAODSIM", dbFile=dbFile, redirector=redirector, xSection=224.2, overwrite=ov) #LO without 1.23 k-factor
-#DYJetsToLL_M4to50_HT100to200_ext = Sample.nanoAODfromDAS("DYJetsToLL_M4to50_HT100to200_ext", "/DYJetsToLL_M-4to50_HT-100to200_TuneCP5_13TeV-madgraphMLM-pythia8/RunIIFall17NanoAOD-PU2017_12Apr2018_94X_mc2017_realistic_v14_ext1-v1/NANOAODSIM", dbFile=dbFile, redirector=redirector, xSection=224.2, overwrite=ov) #LO without 1.23 k-factor
-#DYJetsToLL_M4to50_HT200to400     = Sample.nanoAODfromDAS("DYJetsToLL_M4to50_HT200to400"    , "/DYJetsToLL_M-4to50_HT-200to400_TuneCP5_13TeV-madgraphMLM-pythia8/RunIIFall17NanoAOD-PU2017_12Apr2018_94X_mc2017_realistic_v14_ext1-v1/NANOAODSIM", dbFile=dbFile, redirector=redirector, xSection=37.2, overwrite=ov) #LO without 1.23 k-factor
-#DYJetsToLL_M4to50_HT400to600     = Sample.nanoAODfromDAS("DYJetsToLL_M4to50_HT400to600"    , "/DYJetsToLL_M-4to50_HT-400to600_TuneCP5_13TeV-madgraphMLM-pythia8/RunIIFall17NanoAOD-PU2017_12Apr2018_94X_mc2017_realistic_v14_ext1-v1/NANOAODSIM", dbFile=dbFile, redirector=redirector, xSection=3.581, overwrite=ov) #LO without 1.23 k-factor
-#DYJetsToLL_M4to50_HT600toInf     = Sample.nanoAODfromDAS("DYJetsToLL_M4to50_HT600toInf"    , "/DYJetsToLL_M-4to50_HT-600toInf_TuneCP5_13TeV-madgraphMLM-pythia8/RunIIFall17NanoAOD-PU2017_12Apr2018_94X_mc2017_realistic_v14-v1/NANOAODSIM", dbFile=dbFile, redirector=redirector, xSection=1.124, overwrite=ov) #LO without 1.23 k-factor
+
+# DY HT bins, M_{ll} [4, 50]
+#DYJetsToLL_M4to50_HT70to100      = Sample.nanoAODfromDAS("DYJetsToLL_M4to50_HT70to100",      "/DYJetsToLL_M-4to50_HT-70to100_TuneCP5_13TeV-madgraphMLM-pythia8/RunIIFall17NanoAOD-PU2017_12Apr2018_94X_mc2017_realistic_v14_ext1-v1/NANOAODSIM",                     dbFile=dbFile, redirector=redirector, xSection=303.4, overwrite=ov) #LO without 1.23 k-factor # NOTE: missing
+DYJetsToLL_M4to50_HT100to200     = Sample.nanoAODfromDAS("DYJetsToLL_M4to50_HT100to200",     "/DYJetsToLL_M-4to50_HT-100to200_TuneCP5_13TeV-madgraphMLM-pythia8/RunIIFall17NanoAODv4-PU2017_12Apr2018_Nano14Dec2018_102X_mc2017_realistic_v6-v1/NANOAODSIM",         dbFile=dbFile, redirector=redirector, xSection=224.2, overwrite=ov) #LO without 1.23 k-factor
+DYJetsToLL_M4to50_HT100to200_ext = Sample.nanoAODfromDAS("DYJetsToLL_M4to50_HT100to200_ext", "/DYJetsToLL_M-4to50_HT-100to200_TuneCP5_13TeV-madgraphMLM-pythia8/RunIIFall17NanoAODv4-PU2017_12Apr2018_Nano14Dec2018_102X_mc2017_realistic_v6_ext1-v1/NANOAODSIM",    dbFile=dbFile, redirector=redirector, xSection=224.2, overwrite=ov) #LO without 1.23 k-factor
+DYJetsToLL_M4to50_HT200to400     = Sample.nanoAODfromDAS("DYJetsToLL_M4to50_HT200to400",     "/DYJetsToLL_M-4to50_HT-200to400_TuneCP5_13TeV-madgraphMLM-pythia8/RunIIFall17NanoAODv4-PU2017_12Apr2018_Nano14Dec2018_new_pmx_102X_mc2017_realistic_v6-v1/NANOAODSIM", dbFile=dbFile, redirector=redirector, xSection=37.2,  overwrite=ov) #LO without 1.23 k-factor
+#DYJetsToLL_M4to50_HT200to400     = Sample.nanoAODfromDAS("DYJetsToLL_M4to50_HT200to400",     "/DYJetsToLL_M-4to50_HT-200to400_TuneCP5_13TeV-madgraphMLM-pythia8/RunIIFall17NanoAODv4-PU2017_12Apr2018_Nano14Dec2018_102X_mc2017_realistic_v6-v1/NANOAODSIM",         dbFile=dbFile, redirector=redirector, xSection=37.2,  overwrite=ov) #LO without 1.23 k-factor # NOTE: superseded by new pmx?
+DYJetsToLL_M4to50_HT200to400_ext = Sample.nanoAODfromDAS("DYJetsToLL_M4to50_HT200to400_ext", "/DYJetsToLL_M-4to50_HT-200to400_TuneCP5_13TeV-madgraphMLM-pythia8/RunIIFall17NanoAODv4-PU2017_12Apr2018_Nano14Dec2018_102X_mc2017_realistic_v6_ext1-v1/NANOAODSIM",    dbFile=dbFile, redirector=redirector, xSection=37.2,  overwrite=ov) #LO without 1.23 k-factor
+DYJetsToLL_M4to50_HT400to600     = Sample.nanoAODfromDAS("DYJetsToLL_M4to50_HT400to600",     "/DYJetsToLL_M-4to50_HT-400to600_TuneCP5_13TeV-madgraphMLM-pythia8/RunIIFall17NanoAODv4-PU2017_12Apr2018_Nano14Dec2018_102X_mc2017_realistic_v6-v1/NANOAODSIM",         dbFile=dbFile, redirector=redirector, xSection=3.581, overwrite=ov) #LO without 1.23 k-factor
+DYJetsToLL_M4to50_HT400to600_ext = Sample.nanoAODfromDAS("DYJetsToLL_M4to50_HT400to600_ext", "/DYJetsToLL_M-4to50_HT-400to600_TuneCP5_13TeV-madgraphMLM-pythia8/RunIIFall17NanoAODv4-PU2017_12Apr2018_Nano14Dec2018_102X_mc2017_realistic_v6_ext1-v1/NANOAODSIM",    dbFile=dbFile, redirector=redirector, xSection=3.581, overwrite=ov) #LO without 1.23 k-factor
+DYJetsToLL_M4to50_HT600toInf     = Sample.nanoAODfromDAS("DYJetsToLL_M4to50_HT600toInf",     "/DYJetsToLL_M-4to50_HT-600toInf_TuneCP5_13TeV-madgraphMLM-pythia8/RunIIFall17NanoAODv4-PU2017_12Apr2018_Nano14Dec2018_102X_mc2017_realistic_v6-v1/NANOAODSIM",         dbFile=dbFile, redirector=redirector, xSection=1.124, overwrite=ov) #LO without 1.23 k-factor
+DYJetsToLL_M4to50_HT600toInf_ext = Sample.nanoAODfromDAS("DYJetsToLL_M4to50_HT600toInf_ext", "/DYJetsToLL_M-4to50_HT-600toInf_TuneCP5_13TeV-madgraphMLM-pythia8/RunIIFall17NanoAODv4-PU2017_12Apr2018_Nano14Dec2018_102X_mc2017_realistic_v6_ext1-v1/NANOAODSIM",    dbFile=dbFile, redirector=redirector, xSection=1.124, overwrite=ov) #LO without 1.23 k-factor
+
 
 DYJetsM5to50HT = [
     #DYJetsToLL_M4to50_HT70to100,
-    #DYJetsToLL_M4to50_HT100to200,
-    #DYJetsToLL_M4to50_HT100to200_ext,
-    #DYJetsToLL_M4to50_HT200to400,
-    #DYJetsToLL_M4to50_HT400to600,
-    #DYJetsToLL_M4to50_HT600toInf,
+    DYJetsToLL_M4to50_HT100to200,
+    DYJetsToLL_M4to50_HT100to200_ext,
+    DYJetsToLL_M4to50_HT200to400,
+    DYJetsToLL_M4to50_HT200to400_ext,
+    DYJetsToLL_M4to50_HT400to600,
+    DYJetsToLL_M4to50_HT400to600_ext,
+    DYJetsToLL_M4to50_HT600toInf,
+    DYJetsToLL_M4to50_HT600toInf_ext,
 ]
 
 DY += DYJetsM50HT + DYJetsM5to50HT
 
-## ttbar
+### TTbar
 TTLep_pow      = Sample.nanoAODfromDAS("TTLep_pow",     "/TTTo2L2Nu_TuneCP5_PSweights_13TeV-powheg-pythia8/RunIIFall17NanoAODv4-PU2017_12Apr2018_Nano14Dec2018_new_pmx_102X_mc2017_realistic_v6-v1/NANOAODSIM", dbFile=dbFile, redirector=redirector, xSection=831.76*((3*0.108)**2) , overwrite=ov)
 TTSemiLep_pow  = Sample.nanoAODfromDAS("TTSemiLep_pow", "/TTToSemiLeptonic_TuneCP5_13TeV-powheg-pythia8/RunIIFall17NanoAODv4-PU2017_12Apr2018_Nano14Dec2018_new_pmx_102X_mc2017_realistic_v6-v1/NANOAODSIM",    dbFile=dbFile, redirector=redirector, xSection=831.76*(3*0.108)*(1-3*0.108)*2 , overwrite=ov)
 TTHad_pow      = Sample.nanoAODfromDAS("TTHad_pow",     "/TTToHadronic_TuneCP5_13TeV-powheg-pythia8/RunIIFall17NanoAODv4-PU2017_12Apr2018_Nano14Dec2018_new_pmx_102X_mc2017_realistic_v6-v1/NANOAODSIM",        dbFile=dbFile, redirector=redirector, xSection=831.76*((1-3*0.108)**2) , overwrite=ov)
 #TTbar          = Sample.nanoAODfromDAS("TTbar", "/TT_TuneCUETP8M2T4_13TeV-powheg-pythia8/RunIIFall17NanoAOD-PUMoriond17_94X_mcRun2_asymptotic_v2-v1/NANOAODSIM", dbFile=dbFile, redirector=redirector, xSection=831.76, overwrite=ov)
 
-## single top
+## TTbar+jets
+TTJets_amcatnlo   = Sample.nanoAODfromDAS("TTJets_amcatnlo",   "/TTJets_TuneCUETP8M2T4_13TeV-amcatnloFXFX-pythia8/RunIISummer16NanoAOD-PUMoriond17_05Feb2018_94X_mcRun2_asymptotic_v2-v1/NANOAODSIM",          dbFile=dbFile, overwrite=ov, redirector=redirector, xSection=831.762)
+
+# leptonic
+TTJets_DiLept     = Sample.nanoAODfromDAS("TTJets_DiLept",     "/TTJets_DiLept_TuneCP5_13TeV-madgraphMLM-pythia8/RunIIFall17NanoAODv4-PU2017_12Apr2018_Nano14Dec2018_102X_mc2017_realistic_v6-v1/NANOAODSIM",      dbFile=dbFile, overwrite=ov, redirector=redirector, xSection=87.31483776) # NOTE: genMET-150 version exists
+
+TTJets_SingleLeptonFromT        = Sample.nanoAODfromDAS("TTJets_SingleLeptonFromT",        "/TTJets_SingleLeptFromT_TuneCP5_13TeV-madgraphMLM-pythia8/RunIIFall17NanoAODv4-PU2017_12Apr2018_Nano14Dec2018_102X_mc2017_realistic_v6-v1/NANOAODSIM",         dbFile=dbFile, overwrite=ov, redirector=redirector, xSection=182.17540224) # NOTE: genMET-150 version exists
+TTJets_SingleLeptonFromTbar     = Sample.nanoAODfromDAS("TTJets_SingleLeptonFromTbar",     "/TTJets_SingleLeptFromTbar_TuneCP5_13TeV-madgraphMLM-pythia8/RunIIFall17NanoAODv4-PU2017_12Apr2018_Nano14Dec2018_102X_mc2017_realistic_v6-v1/NANOAODSIM",      dbFile=dbFile, overwrite=ov, redirector=redirector, xSection=182.17540224) # NOTE: genMET-150 version exists
+
+TTJets = [
+    TTJets_amcatnlo,
+    TTJets_DiLept,
+    TTJets_SingleLeptonFromT,
+    TTJets_SingleLeptonFromTbar,
+    ]
+
+### Single Top
+# NOTE: x-check xsecs (https://twiki.cern.ch/twiki/bin/viewauth/CMS/SingleTopSigma)
+
 #TToLeptons_sch_amcatnlo = Sample.nanoAODfromDAS("TToLeptons_sch_amcatnlo", "/ST_s-channel_4f_leptonDecays_TuneCP5_PSweights_13TeV-amcatnlo-pythia8/RunIIFall17NanoAOD-PU2017_12Apr2018_94X_mc2017_realistic_v14-v1/NANOAODSIM", dbFile=dbFile, redirector=redirector, xSection=(7.20+4.16)*0.108*3, overwrite=ov)
 
-T_tch_powheg            = Sample.nanoAODfromDAS("T_tch_powheg",    "/ST_t-channel_top_4f_InclusiveDecays_TuneCP5_PSweights_13TeV-powheg-pythia8/RunIIFall17NanoAODv4-PU2017_12Apr2018_Nano14Dec2018_102X_mc2017_realistic_v6-v1/NANOAODSIM", dbFile=dbFile, redirector=redirector, xSection=136.02, overwrite=ov) # inclusive sample
-TBar_tch_powheg         = Sample.nanoAODfromDAS("TBar_tch_powheg", "/ST_t-channel_antitop_4f_InclusiveDecays_TuneCP5_PSweights_13TeV-powheg-pythia8/RunIIFall17NanoAODv4-PU2017_12Apr2018_Nano14Dec2018_102X_mc2017_realistic_v6-v1/NANOAODSIM", dbFile=dbFile, redirector=redirector, xSection=80.95, overwrite=ov) # inclusive sample
+T_tch_powheg    = Sample.nanoAODfromDAS("T_tch_powheg",    "/ST_t-channel_top_4f_InclusiveDecays_TuneCP5_PSweights_13TeV-powheg-pythia8/RunIIFall17NanoAODv4-PU2017_12Apr2018_Nano14Dec2018_102X_mc2017_realistic_v6-v1/NANOAODSIM",         dbFile=dbFile, redirector=redirector, xSection=136.02, overwrite=ov) # inclusive sample # NOTE: PSweights version
+#T_tch_powheg    = Sample.nanoAODfromDAS("T_tch_powheg",    "/ST_t-channel_top_4f_inclusiveDecays_TuneCP5_13TeV-powhegV2-madspin-pythia8/RunIIFall17NanoAODv4-PU2017_12Apr2018_Nano14Dec2018_new_pmx_102X_mc2017_realistic_v6-v1/NANOAODSIM", dbFile=dbFile, redirector=redirector, xSection=136.02, overwrite=ov) # inclusive sample # NOTE: PSweights version exists - supersedes this?
+TBar_tch_powheg = Sample.nanoAODfromDAS("TBar_tch_powheg", "/ST_t-channel_antitop_4f_InclusiveDecays_TuneCP5_PSweights_13TeV-powheg-pythia8/RunIIFall17NanoAODv4-PU2017_12Apr2018_Nano14Dec2018_102X_mc2017_realistic_v6-v1/NANOAODSIM",     dbFile=dbFile, redirector=redirector, xSection=80.95,  overwrite=ov) # inclusive sample # NOTE: PSweights version
+#TBar_tch_powheg = Sample.nanoAODfromDAS("TBar_tch_powheg", "/ST_t-channel_antitop_4f_inclusiveDecays_TuneCP5_13TeV-powhegV2-madspin-pythia8/RunIIFall17NanoAODv4-PU2017_12Apr2018_Nano14Dec2018_102X_mc2017_realistic_v6-v1/NANOAODSIM",     dbFile=dbFile, redirector=redirector, xSection=80.95,  overwrite=ov) # inclusive sample # NOTE: PSweights version exists - supersedes this?
 
-#T_tWch_ext              = Sample.nanoAODfromDAS("T_tWch_ext",    "", dbFile=dbFile, redirector=redirector, xSection=35.6, overwrite=ov)
-#TBar_tWch_ext           = Sample.nanoAODfromDAS("TBar_tWch_ext", "/ST_tW_antitop_5f_NoFullyHadronicDecays_TuneCP5_PSweights_13TeV-powheg-pythia8/RunIIFall17NanoAOD-PU2017_12Apr2018_94X_mc2017_realistic_v14-v1/NANOAODSIM", dbFile=dbFile, redirector=redirector, xSection=35.6, overwrite=ov)
+# NOTE: what about ST_t-channel_(anti)top_5f?
+
+T_tWch          = Sample.nanoAODfromDAS("T_tWch",          "/ST_tW_top_5f_inclusiveDecays_TuneCP5_PSweights_13TeV-powheg-pythia8/RunIIFall17NanoAODv4-PU2017_12Apr2018_Nano14Dec2018_new_pmx_102X_mc2017_realistic_v6-v1/NANOAODSIM",        dbFile=dbFile, redirector=redirector, xSection=35.85, overwrite=ov) # NOTE: NNLO xsec from twiki # NOTE: PSweights version
+#T_tWch          = Sample.nanoAODfromDAS("T_tWch",          "/ST_tW_top_5f_inclusiveDecays_TuneCP5_13TeV-powheg-pythia8/RunIIFall17NanoAODv4-PU2017_12Apr2018_Nano14Dec2018_102X_mc2017_realistic_v6-v1/NANOAODSIM",                          dbFile=dbFile, redirector=redirector, xSection=35.85, overwrite=ov) # NOTE: NNLO xsec from twiki # NOTE: PSweights version exists - supersedes this?
+TBar_tWch       = Sample.nanoAODfromDAS("TBar_tWch",       "/ST_tW_antitop_5f_inclusiveDecays_TuneCP5_PSweights_13TeV-powheg-pythia8/RunIIFall17NanoAODv4-PU2017_12Apr2018_Nano14Dec2018_102X_mc2017_realistic_v6-v1/NANOAODSIM",            dbFile=dbFile, redirector=redirector, xSection=35.85, overwrite=ov) # NOTE: NNLO xsec from twiki # NOTE: PSweights version
+#TBar_tWch       = Sample.nanoAODfromDAS("TBar_tWch",       "/ST_tW_antitop_5f_inclusiveDecays_TuneCP5_13TeV-powheg-pythia8/RunIIFall17NanoAODv4-PU2017_12Apr2018_Nano14Dec2018_102X_mc2017_realistic_v6-v1/NANOAODSIM",                      dbFile=dbFile, redirector=redirector, xSection=35.85, overwrite=ov) # NOTE: NNLO xsec from twiki # NOTE: PSweights version exists - supersedes this?
 
 ## ttH
 #TTHbb                   = Sample.nanoAODfromDAS("TTHbb",                  "/ttHJetTobb_M125_13TeV_amcatnloFXFX_madspin_pythia8/RunIISummer16NanoAOD-PUMoriond17_05Feb2018_94X_mcRun2_asymptotic_v2_ext3-v1/NANOAODSIM", dbFile=dbFile, redirector=redirector, xSection=0.5085*(0.577), overwrite=ov)
@@ -122,6 +157,9 @@ TBar_tch_powheg         = Sample.nanoAODfromDAS("TBar_tch_powheg", "/ST_t-channe
 #THW = Sample.nanoAODfromDAS("THW", "/THW_5f_Hincl_13TeV_madgraph_pythia8/RunIIFall17NanoAOD-PU2017_12Apr2018_94X_mc2017_realistic_v14-v1/NANOAODSIM", dbFile=dbFile, redirector=redirector, xSection=0.1472, overwrite=ov)
 
 ## ttV
+TTW_LO              = Sample.nanoAODfromDAS("TTW_LO", "/ttWJets_TuneCP5_13TeV_madgraphMLM_pythia8/RunIIFall17NanoAODv4-PU2017_12Apr2018_Nano14Dec2018_102X_mc2017_realistic_v6_ext1-v1/NANOAODSIM",  dbFile=dbFile, redirector=redirector, xSection=0.6105 , overwrite=ov)
+TTZ_LO              = Sample.nanoAODfromDAS("TTZ_LO", "/ttZJets_TuneCP5_13TeV_madgraphMLM_pythia8/RunIIFall17NanoAODv4-PU2017_12Apr2018_Nano14Dec2018_102X_mc2017_realistic_v6_ext1-v1/NANOAODSIM", dbFile=dbFile, redirector=redirector, xSection=0.5297/0.692, overwrite=ov)
+
 #TGJets              = Sample.nanoAODfromDAS("TGJets",     "/TGJets_TuneCP5_13TeV_amcatnlo_madspin_pythia8/RunIIFall17NanoAOD-PU2017_12Apr2018_94X_mc2017_realistic_v14-v2/NANOAODSIM", dbFile=dbFile, redirector=redirector, xSection=2.967, overwrite=ov)
 tZq_ll_ext          = Sample.nanoAODfromDAS("tZq_ll_ext", "/tZq_ll_4f_ckm_NLO_TuneCP5_PSweights_13TeV-amcatnlo-pythia8/RunIIFall17NanoAODv4-PU2017_12Apr2018_Nano14Dec2018_new_pmx_102X_mc2017_realistic_v6-v1/NANOAODSIM", dbFile=dbFile, redirector=redirector, xSection=0.09418 , overwrite=ov) #0.0758 )
 #tWll                = Sample.nanoAODfromDAS("tWll",       "/ST_tWll_5f_LO_13TeV-MadGraph-pythia8/RunIISummer16NanoAOD-PUMoriond17_05Feb2018_94X_mcRun2_asymptotic_v2-v1/NANOAODSIM", dbFile=dbFile, redirector=redirector, xSection=0.01123, overwrite=ov)
@@ -129,11 +167,9 @@ tZq_ll_ext          = Sample.nanoAODfromDAS("tZq_ll_ext", "/tZq_ll_4f_ckm_NLO_Tu
 
 #TTWToLNu            = Sample.nanoAODfromDAS("TTWToLNu", "/TTWJetsToLNu_TuneCP5_PSweights_13TeV-amcatnloFXFX-madspin-pythia8/RunIIFall17NanoAOD-PU2017_12Apr2018_94X_mc2017_realistic_v14-v1/NANOAODSIM", dbFile=dbFile, redirector=redirector, xSection=0.2043, overwrite=ov)
 #TTWToQQ             = Sample.nanoAODfromDAS("TTWToQQ", "/TTWJetsToQQ_TuneCUETP8M1_13TeV-amcatnloFXFX-madspin-pythia8/RunIISummer16NanoAOD-PUMoriond17_05Feb2018_94X_mcRun2_asymptotic_v2-v1/NANOAODSIM", dbFile=dbFile, redirector=redirector, xSection=0.40620, overwrite=ov)
-TTW_LO              = Sample.nanoAODfromDAS("TTW_LO", "/ttWJets_TuneCP5_13TeV_madgraphMLM_pythia8/RunIIFall17NanoAODv4-PU2017_12Apr2018_Nano14Dec2018_102X_mc2017_realistic_v6_ext1-v1/NANOAODSIM",  dbFile=dbFile, redirector=redirector, xSection=0.6105 , overwrite=ov)
 #TTZToQQ             = Sample.nanoAODfromDAS("TTZToQQ","/TTZToQQ_TuneCUETP8M1_13TeV-amcatnlo-pythia8/RunIISummer16NanoAOD-PUMoriond17_05Feb2018_94X_mcRun2_asymptotic_v2-v1/NANOAODSIM", dbFile=dbFile, redirector=redirector, xSection=0.5297, overwrite=ov)
 #TTZToLLNuNu         = Sample.nanoAODfromDAS("TTZToLLNuNu", "/TTZToLLNuNu_M-10_TuneCP5_13TeV-amcatnlo-pythia8/RunIIFall17NanoAOD-PU2017_12Apr2018_94X_mc2017_realistic_v14-v1/NANOAODSIM", dbFile=dbFile, redirector=redirector, xSection=0.2728, overwrite=ov)
 #TTZToLLNuNu_m1to10  = Sample.nanoAODfromDAS("TTZToLLNuNu_m1to10", "/TTZToLL_M-1to10_TuneCP5_13TeV-amcatnlo-pythia8/RunIIFall17NanoAOD-PU2017_12Apr2018_94X_mc2017_realistic_v14-v1/NANOAODSIM", dbFile=dbFile, redirector=redirector, xSection=0.0493, overwrite=ov)
-TTZ_LO              = Sample.nanoAODfromDAS("TTZ_LO", "/ttZJets_TuneCP5_13TeV_madgraphMLM_pythia8/RunIIFall17NanoAODv4-PU2017_12Apr2018_Nano14Dec2018_102X_mc2017_realistic_v6_ext1-v1/NANOAODSIM", dbFile=dbFile, redirector=redirector, xSection=0.5297/0.692, overwrite=ov)
 
 TTGJets             = Sample.nanoAODfromDAS("TTGJets",    "/TTGJets_TuneCP5_13TeV-amcatnloFXFX-madspin-pythia8/RunIIFall17NanoAODv4-PU2017_12Apr2018_Nano14Dec2018_102X_mc2017_realistic_v6_ext1-v1/NANOAODSIM", dbFile=dbFile, redirector=redirector, xSection=3.697, overwrite=ov)
 #TTGJets_ext         = Sample.nanoAODfromDAS("TTGJets_ext","/TTGJets_TuneCP5_13TeV-amcatnloFXFX-madspin-pythia8/RunIIFall17NanoAOD-PU2017_12Apr2018_94X_mc2017_realistic_v14_ext1-v1/NANOAODSIM", dbFile=dbFile, redirector=redirector, xSection=3.697, overwrite=ov)
@@ -143,6 +179,11 @@ TTGJets             = Sample.nanoAODfromDAS("TTGJets",    "/TTGJets_TuneCP5_13Te
 #TTGSemiT            = Sample.nanoAODfromDAS("TTGSemiT",    "/TTGamma_SingleLeptFromT_TuneCP5_PSweights_13TeV_madgraph_pythia8/RunIIFall17NanoAOD-PU2017_12Apr2018_94X_mc2017_realistic_v14-v1/NANOAODSIM", dbFile=dbFile, redirector=redirector, xSection=0.769*2.028673602, overwrite=ov)
 #TTGLep              = Sample.nanoAODfromDAS("TTGLep",      "/TTGamma_Dilept_TuneCP5_PSweights_13TeV_madgraph_pythia8/RunIIFall17NanoAOD-PU2017_12Apr2018_94X_mc2017_realistic_v14-v1/NANOAODSIM", dbFile=dbFile, redirector=redirector, xSection=0.607*1.574299835, overwrite=ov)
 
+TTV_LO = [
+    TTW_LO,
+    TTZ_LO,
+    ]
+
 TTV = [
 #    TGJets,
 #    TGJets_ext,
@@ -151,55 +192,64 @@ TTV = [
 #    tWnunu,
 #    TTWToLNu,
 #    TTWToQQ,
-    TTW_LO,
 #    TTZToQQ,
 #    TTZToLLNuNu,
 #    TTZToLLNuNu_m1to10,
-    TTZ_LO,
     TTGJets,
 #    TTGJets_ext,
 #    TTGHad,
 #    TTGSemiTbar,
 #    TTGSemiT,
 #    TTGLep,
-]
+    ] + TTV_LO
+
+ST = [
+    #TToLeptons_sch_amcatnlo,
+    T_tch_powheg,
+    TBar_tch_powheg,
+    T_tWch,
+    TBar_tWch,
+    ]
 
 top = [
     TTLep_pow,
     TTSemiLep_pow,
     TTHad_pow,
 #    TTbar,
-#    TToLeptons_sch_amcatnlo,
-    T_tch_powheg,
-    TBar_tch_powheg,
-#    T_tWch_ext,
-#    TBar_tWch_ext,
 #    TTHbb,
 #    TTHnobb_pow,
 #    TTHnobb_mWCutfix_ext,
 #    THQ,
 #    THW,
-    ] + TTV
+    ] + TTJets + ST + TTV
 
-## di/multiboson
-#WWTo2L2Nu       = Sample.nanoAODfromDAS("WWTo2L2Nu",     "/WWTo2L2Nu_NNPDF31_TuneCP5_13TeV-powheg-pythia8/RunIIFall17NanoAOD-PU2017_12Apr2018_94X_mc2017_realistic_v14-v1/NANOAODSIM", dbFile=dbFile, redirector=redirector, xSection=10.481 , overwrite=ov)
-#WWToLNuQQ       = Sample.nanoAODfromDAS("WWToLNuQQ",     "/WWToLNuQQ_NNPDF31_TuneCP5_13TeV-powheg-pythia8/RunIIFall17NanoAOD-PU2017_12Apr2018_94X_mc2017_realistic_v14-v1/NANOAODSIM", dbFile=dbFile, redirector=redirector, xSection=43.53 , overwrite=ov)
-#WWToLNuQQ_ext   = Sample.nanoAODfromDAS("WWToLNuQQ_ext", "/WWToLNuQQ_NNPDF31_TuneCP5_13TeV-powheg-pythia8/RunIIFall17NanoAOD-PU2017_12Apr2018_94X_mc2017_realistic_v14_ext1-v1/NANOAODSIM", dbFile=dbFile, redirector=redirector, xSection=43.53 , overwrite=ov)
-#WWTo1L1Nu2Q     = Sample.nanoAODfromDAS("WWTo1L1Nu2Q",   "/WWTo1L1Nu2Q_13TeV_amcatnloFXFX_madspin_pythia8/RunIIFall17NanoAOD-PU2017_12Apr2018_94X_mc2017_realistic_v14-v1/NANOAODSIM", dbFile=dbFile, redirector=redirector, xSection=49.997 , overwrite=ov)
+### di/multiboson
+# NOTE: x-check xsec (https://twiki.cern.ch/twiki/bin/view/CMS/SummaryTable1G25ns#Diboson)
 
-#ZZTo2L2Nu       = Sample.nanoAODfromDAS("ZZTo2L2Nu",   "/ZZTo2L2Nu_13TeV_powheg_pythia8/RunIIFall17NanoAOD-PU2017_12Apr2018_94X_mc2017_realistic_v14-v1/NANOAODSIM", dbFile=dbFile, redirector=redirector, xSection=0.564, overwrite=ov)
-ZZTo2L2Q        = Sample.nanoAODfromDAS("ZZTo2L2Q",    "/ZZTo2L2Q_13TeV_amcatnloFXFX_madspin_pythia8/RunIIFall17NanoAODv4-PU2017_12Apr2018_Nano14Dec2018_102X_mc2017_realistic_v6-v1/NANOAODSIM",  dbFile=dbFile, redirector=redirector, xSection=3.28, overwrite=ov)
-ZZTo2Q2Nu       = Sample.nanoAODfromDAS("ZZTo2Q2Nu",   "/ZZTo2Q2Nu_TuneCP5_13TeV_amcatnloFXFX_madspin_pythia8/RunIIFall17NanoAODv4-PU2017_12Apr2018_Nano14Dec2018_102X_mc2017_realistic_v6-v1/NANOAODSIM",  dbFile=dbFile, redirector=redirector, xSection=4.04, overwrite=ov)
-ZZTo4L          = Sample.nanoAODfromDAS("ZZTo4L",      "/ZZTo4L_13TeV_powheg_pythia8/RunIIFall17NanoAODv4-PU2017_12Apr2018_Nano14Dec2018_102X_mc2017_realistic_v6-v1/NANOAODSIM", dbFile=dbFile, redirector=redirector, xSection=1.256*1.1, overwrite=ov)
-ZZTo4L_ext1     = Sample.nanoAODfromDAS("ZZTo4L_ext1", "/ZZTo4L_13TeV_powheg_pythia8/RunIIFall17NanoAODv4-PU2017_12Apr2018_Nano14Dec2018_102X_mc2017_realistic_v6_ext1-v1/NANOAODSIM", dbFile=dbFile, redirector=redirector, xSection=1.256*1.1, overwrite=ov)
+WWTo2L2Nu     = Sample.nanoAODfromDAS("WWTo2L2Nu",     "/WWTo2L2Nu_NNPDF31_TuneCP5_13TeV-powheg-pythia8/RunIIFall17NanoAODv4-PU2017_12Apr2018_Nano14Dec2018_102X_mc2017_realistic_v6-v1/NANOAODSIM",                dbFile=dbFile, redirector=redirector, xSection=12.178, overwrite=ov) # NOTE: NNLO x-sec from twiki
+WWTo2L2Nu_ext = Sample.nanoAODfromDAS("WWTo2L2Nu_ext", "/WWTo2L2Nu_NNPDF31_TuneCP5_PSweights_13TeV-powheg-pythia8/RunIIFall17NanoAODv4-PU2017_12Apr2018_Nano14Dec2018_102X_mc2017_realistic_v6_ext1-v1/NANOAODSIM", dbFile=dbFile, redirector=redirector, xSection=12.178, overwrite=ov) # NOTE: NNLO x-sec from twiki # NOTE: PS weights version
+WWToLNuQQ     = Sample.nanoAODfromDAS("WWToLNuQQ",     "/WWToLNuQQ_NNPDF31_TuneCP5_13TeV-powheg-pythia8/RunIIFall17NanoAODv4-PU2017_12Apr2018_Nano14Dec2018_new_pmx_102X_mc2017_realistic_v6-v1/NANOAODSIM",        dbFile=dbFile, redirector=redirector, xSection=49.997, overwrite=ov) # NOTE: NNLO x-sec from twiki
+WWToLNuQQ_ext = Sample.nanoAODfromDAS("WWToLNuQQ_ext", "/WWToLNuQQ_NNPDF31_TuneCP5_PSweights_13TeV-powheg-pythia8/RunIIFall17NanoAODv4-PU2017_12Apr2018_Nano14Dec2018_102X_mc2017_realistic_v6_ext1-v1/NANOAODSIM", dbFile=dbFile, redirector=redirector, xSection=49.997, overwrite=ov) # NOTE: NNLO x-sec from twiki # NOTE: PS weights version 
+#WWToLNuQQ_ext = Sample.nanoAODfromDAS("WWToLNuQQ_ext", "/WWToLNuQQ_NNPDF31_TuneCP5_13TeV-powheg-pythia8/RunIIFall17NanoAODv4-PU2017_12Apr2018_Nano14Dec2018_102X_mc2017_realistic_v6_ext1-v1/NANOAODSIM",           dbFile=dbFile, redirector=redirector, xSection=43.53, overwrite=ov) # NOTE: PSweights version exists - supersedes this?
+WWTo1L1Nu2Q   = Sample.nanoAODfromDAS("WWTo1L1Nu2Q",   "/WWTo1L1Nu2Q_13TeV_amcatnloFXFX_madspin_pythia8/RunIIFall17NanoAODv4-PU2017_12Apr2018_Nano14Dec2018_102X_mc2017_realistic_v6-v1/NANOAODSIM",                dbFile=dbFile, redirector=redirector, xSection=49.997, overwrite=ov)
+
+WZTo1L3Nu         = Sample.nanoAODfromDAS("WZTo1L3Nu",         "/WZTo1L3Nu_13TeV_amcatnloFXFX_madspin_pythia8_v2/RunIIFall17NanoAODv4-PU2017_12Apr2018_Nano14Dec2018_102X_mc2017_realistic_v6-v1/NANOAODSIM",     dbFile=dbFile, redirector=redirector, xSection=(47.13)*(3*0.108)*(0.2), overwrite=ov)
+WZTo1L1Nu2Q       = Sample.nanoAODfromDAS("WZTo1L1Nu2Q",       "/WZTo1L1Nu2Q_13TeV_amcatnloFXFX_madspin_pythia8/RunIIFall17NanoAODv4-PU2017_12Apr2018_Nano14Dec2018_102X_mc2017_realistic_v6-v1/NANOAODSIM",      dbFile=dbFile, redirector=redirector, xSection=10.71,    overwrite=ov)
+WZTo2L2Q          = Sample.nanoAODfromDAS("WZTo2L2Q",          "/WZTo2L2Q_13TeV_amcatnloFXFX_madspin_pythia8/RunIIFall17NanoAODv4-PU2017_12Apr2018_Nano14Dec2018_102X_mc2017_realistic_v6-v1/NANOAODSIM",         dbFile=dbFile, redirector=redirector, xSection=5.60,     overwrite=ov)
+WZTo3LNu          = Sample.nanoAODfromDAS("WZTo3LNu",          "/WZTo3LNu_TuneCP5_13TeV-amcatnloFXFX-pythia8/RunIIFall17NanoAODv4-PU2017_12Apr2018_Nano14Dec2018_new_pmx_102X_mc2017_realistic_v6-v1/NANOAODSIM", dbFile=dbFile, redirector=redirector, xSection=4.42965,  overwrite=ov)
+
+WZTo3LNu_amcatnlo = Sample.nanoAODfromDAS("WZTo3LNu_amcatnlo", "/WZTo3LNu_TuneCP5_13TeV-amcatnloFXFX-pythia8/RunIIFall17NanoAODv4-PU2017_12Apr2018_Nano14Dec2018_new_pmx_102X_mc2017_realistic_v6-v1/NANOAODSIM", dbFile=dbFile, redirector=redirector, xSection=4.666,    overwrite=ov)
+#WZTo3LNu_mllmin01 =Sample.nanoAODfromDAS("WZTo3LNu_mllmin01", "/WZTo3LNu_mllmin01_13TeV-powheg-pythia8_ext1/RunIISummer16NanoAOD-PUMoriond17_05Feb2018_94X_mcRun2_asymptotic_v2_ext1-v1/NANOAODSIM", dbFile=dbFile, redirector=redirector, xSection=58.59, overwrite=ov)
+# NOTE: WZTo3LNu_*Jets_MLL-* samples exist
 
 #WZJToLLLNu      = Sample.nanoAODfromDAS("WZJToLLLNu",  "/WZJToLLLNu_TuneCUETP8M1_13TeV-amcnlo-pythia8/RunIISummer16MiniAODv2-PUMoriond17_80X_mcRun2_asymptotic_2016_TrancheIV_v6-v1/MINIAODSIM"  , "CMS", ".*root", 4.708 , overwrite=ov)
-#WZTo1L3Nu       = Sample.nanoAODfromDAS("WZTo1L3Nu",   "/WZTo1L3Nu_13TeV_amcatnloFXFX_madspin_pythia8_v2/RunIIFall17NanoAOD-PU2017_12Apr2018_94X_mc2017_realistic_v14-v1/NANOAODSIM", dbFile=dbFile, redirector=redirector, xSection=(47.13)*(3*0.108)*(0.2) , overwrite=ov)
-WZTo1L1Nu2Q     = Sample.nanoAODfromDAS("WZTo1L1Nu2Q", "/WZTo1L1Nu2Q_13TeV_amcatnloFXFX_madspin_pythia8/RunIIFall17NanoAODv4-PU2017_12Apr2018_Nano14Dec2018_102X_mc2017_realistic_v6-v1/NANOAODSIM",  dbFile=dbFile, redirector=redirector, xSection=10.71, overwrite=ov)
-WZTo2L2Q        = Sample.nanoAODfromDAS("WZTo2L2Q",    "/WZTo2L2Q_13TeV_amcatnloFXFX_madspin_pythia8/RunIIFall17NanoAODv4-PU2017_12Apr2018_Nano14Dec2018_102X_mc2017_realistic_v6-v1/NANOAODSIM",  dbFile=dbFile, redirector=redirector, xSection=5.60, overwrite=ov)
-WZTo3LNu        = Sample.nanoAODfromDAS("WZTo3LNu",    "/WZTo3LNu_TuneCP5_13TeV-amcatnloFXFX-pythia8/RunIIFall17NanoAODv4-PU2017_12Apr2018_Nano14Dec2018_new_pmx_102X_mc2017_realistic_v6-v1/NANOAODSIM", dbFile=dbFile, redirector=redirector, xSection=4.42965, overwrite=ov)
-#WZTo3LNu_mllmin01 =Sample.nanoAODfromDAS("WZTo3LNu_mllmin01", "/WZTo3LNu_mllmin01_13TeV-powheg-pythia8_ext1/RunIISummer16NanoAOD-PUMoriond17_05Feb2018_94X_mcRun2_asymptotic_v2_ext1-v1/NANOAODSIM", dbFile=dbFile, redirector=redirector, xSection=58.59, overwrite=ov)
-#WZTo3LNu_amcatnlo =Sample.nanoAODfromDAS("WZTo3LNu_amcatnlo", "/WZTo3LNu_TuneCP5_13TeV-amcatnloFXFX-pythia8/RunIIFall17NanoAOD-PU2017_12Apr2018_94X_mc2017_realistic_v14-v1/NANOAODSIM", dbFile=dbFile, redirector=redirector, xSection=4.666, overwrite=ov)
+
+ZZTo2L2Nu       = Sample.nanoAODfromDAS("ZZTo2L2Nu",   "/ZZTo2L2Nu_13TeV_powheg_pythia8/RunIIFall17NanoAODv4-PU2017_12Apr2018_Nano14Dec2018_102X_mc2017_realistic_v6-v1/NANOAODSIM",                       dbFile=dbFile, redirector=redirector, xSection=0.564,     overwrite=ov)
+ZZTo2L2Q        = Sample.nanoAODfromDAS("ZZTo2L2Q",    "/ZZTo2L2Q_13TeV_amcatnloFXFX_madspin_pythia8/RunIIFall17NanoAODv4-PU2017_12Apr2018_Nano14Dec2018_102X_mc2017_realistic_v6-v1/NANOAODSIM",          dbFile=dbFile, redirector=redirector, xSection=3.28,      overwrite=ov)
+ZZTo2Q2Nu       = Sample.nanoAODfromDAS("ZZTo2Q2Nu",   "/ZZTo2Q2Nu_TuneCP5_13TeV_amcatnloFXFX_madspin_pythia8/RunIIFall17NanoAODv4-PU2017_12Apr2018_Nano14Dec2018_102X_mc2017_realistic_v6-v1/NANOAODSIM", dbFile=dbFile, redirector=redirector, xSection=4.04,      overwrite=ov)
+ZZTo4L          = Sample.nanoAODfromDAS("ZZTo4L",      "/ZZTo4L_13TeV_powheg_pythia8/RunIIFall17NanoAODv4-PU2017_12Apr2018_Nano14Dec2018_new_pmx_102X_mc2017_realistic_v6-v1/NANOAODSIM",                  dbFile=dbFile, redirector=redirector, xSection=1.256*1.1, overwrite=ov)
+#ZZTo4L          = Sample.nanoAODfromDAS("ZZTo4L",      "/ZZTo4L_13TeV_powheg_pythia8/RunIIFall17NanoAODv4-PU2017_12Apr2018_Nano14Dec2018_102X_mc2017_realistic_v6-v1/NANOAODSIM",                          dbFile=dbFile, redirector=redirector, xSection=1.256*1.1, overwrite=ov) # NOTE: superseded by new pmx?
+ZZTo4L_ext1     = Sample.nanoAODfromDAS("ZZTo4L_ext1", "/ZZTo4L_13TeV_powheg_pythia8/RunIIFall17NanoAODv4-PU2017_12Apr2018_Nano14Dec2018_102X_mc2017_realistic_v6_ext1-v1/NANOAODSIM",                     dbFile=dbFile, redirector=redirector, xSection=1.256*1.1, overwrite=ov)
 
 VVTo2L2Nu       = Sample.nanoAODfromDAS("VVTo2L2Nu","/VVTo2L2Nu_13TeV_amcatnloFXFX_madspin_pythia8/RunIIFall17NanoAODv4-PU2017_12Apr2018_Nano14Dec2018_102X_mc2017_realistic_v6-v1/NANOAODSIM",  dbFile=dbFile, redirector=redirector, xSection=11.95, overwrite=ov)
 #VVTo2L2Nu_ext   = Sample.nanoAODfromDAS("VVTo2L2Nu_ext" ,"/VVTo2L2Nu_13TeV_amcatnloFXFX_madspin_pythia8/RunIISummer16NanoAOD-PUMoriond17_05Feb2018_94X_mcRun2_asymptotic_v2_ext1-v1/NANOAODSIM",  dbFile=dbFile, redirector=redirector, xSection=11.95, overwrite=ov)
@@ -229,22 +279,28 @@ VVTo2L2Nu       = Sample.nanoAODfromDAS("VVTo2L2Nu","/VVTo2L2Nu_13TeV_amcatnloFX
 #WZZ     = Sample.nanoAODfromDAS("WZZ", "/WZZ_TuneCP5_13TeV-amcatnlo-pythia8/RunIIFall17NanoAOD-PU2017_12Apr2018_94X_mc2017_realistic_v14-v1/NANOAODSIM", dbFile=dbFile, redirector=redirector, xSection=0.05565, overwrite=ov)
 #ZZZ     = Sample.nanoAODfromDAS("ZZZ", "/ZZZ_TuneCP5_13TeV-amcatnlo-pythia8/RunIIFall17NanoAOD-PU2017_12Apr2018_94X_mc2017_realistic_v14-v2/NANOAODSIM", dbFile=dbFile, redirector=redirector, xSection=0.01398, overwrite=ov)
 
-boson = [
-#    WWTo2L2Nu,
-#    WWToLNuQQ,
-#    WWToLNuQQ_ext,
-#    WWTo1L1Nu2Q,
-#    ZZTo2L2Nu,
+VV_NLO = [
+    WWTo2L2Nu,
+    WWTo2L2Nu_ext,
+    WWToLNuQQ,
+    WWToLNuQQ_ext,
+    WWTo1L1Nu2Q,
+    
+    WZTo1L3Nu,
+    WZTo1L1Nu2Q,
+    WZTo2L2Q,
+    WZTo3LNu,
+    
+    ZZTo2L2Nu,
     ZZTo2L2Q,
     ZZTo2Q2Nu,
     ZZTo4L,
     ZZTo4L_ext1,
-    WZTo1L1Nu2Q,
-#    WZTo1L3Nu,
-    WZTo2L2Q,
-    WZTo3LNu,
+    ]
+
+boson = [
 #    WZTo3LNu_mllmin01,
-#    WZTo3LNu_amcatnlo,
+    WZTo3LNu_amcatnlo,
     VVTo2L2Nu,
 #    VVTo2L2Nu_ext,
 #    WGToLNuG,
@@ -264,16 +320,41 @@ boson = [
 #    WZG,
 #    WZZ,
 #    ZZZ,
-    ]
+    ] + VV_NLO
 
-## W+jets
+### W+jets
+
+## inclusive
 WJetsToLNu      = Sample.nanoAODfromDAS("WJetsToLNu",     "/WJetsToLNu_TuneCP5_13TeV-madgraphMLM-pythia8/RunIIFall17NanoAODv4-PU2017_12Apr2018_Nano14Dec2018_102X_mc2017_realistic_v6-v1/NANOAODSIM", dbFile=dbFile, redirector=redirector, xSection=3* 20508.9, overwrite=ov)
 WJetsToLNu_ext  = Sample.nanoAODfromDAS("WJetsToLNu_ext", "/WJetsToLNu_TuneCP5_13TeV-madgraphMLM-pythia8/RunIIFall17NanoAODv4-PU2017_12Apr2018_Nano14Dec2018_102X_mc2017_realistic_v6_ext1-v1/NANOAODSIM", dbFile=dbFile, redirector=redirector, xSection=3* 20508.9, overwrite=ov)
 
-wjets = [
+wjets_inc = [
     WJetsToLNu,
     WJetsToLNu_ext,
     ]
+
+## HT-binned
+#WJetsToLNu_HT70to100    = Sample.nanoAODfromDAS("WJetsToLNu_HT70to100",    "/WJetsToLNu_HT-70To100_TuneCUETP8M1_13TeV-madgraphMLM-pythia8/RunIISummer16NanoAOD-PUMoriond17_05Feb2018_94X_mcRun2_asymptotic_v2-v1/NANOAODSIM",        dbFile=dbFile, overwrite=ov, redirector=redirector, xSection=1637.13) # NOTE: missing
+WJetsToLNu_HT100to200   = Sample.nanoAODfromDAS("WJetsToLNu_HT100to200",   "/WJetsToLNu_HT-100To200_TuneCP5_13TeV-madgraphMLM-pythia8/RunIIFall17NanoAODv4-PU2017_12Apr2018_Nano14Dec2018_102X_mc2017_realistic_v6-v1/NANOAODSIM",   dbFile=dbFile, overwrite=ov, redirector=redirector, xSection=1627.45)
+WJetsToLNu_HT200to400   = Sample.nanoAODfromDAS("WJetsToLNu_HT200to400",   "/WJetsToLNu_HT-200To400_TuneCP5_13TeV-madgraphMLM-pythia8/RunIIFall17NanoAODv4-PU2017_12Apr2018_Nano14Dec2018_102X_mc2017_realistic_v6-v1/NANOAODSIM",   dbFile=dbFile, overwrite=ov, redirector=redirector, xSection=435.237)
+WJetsToLNu_HT400to600   = Sample.nanoAODfromDAS("WJetsToLNu_HT400to600",   "/WJetsToLNu_HT-400To600_TuneCP5_13TeV-madgraphMLM-pythia8/RunIIFall17NanoAODv4-PU2017_12Apr2018_Nano14Dec2018_102X_mc2017_realistic_v6-v1/NANOAODSIM",   dbFile=dbFile, overwrite=ov, redirector=redirector, xSection=59.1811)
+WJetsToLNu_HT600to800   = Sample.nanoAODfromDAS("WJetsToLNu_HT600to800",   "/WJetsToLNu_HT-600To800_TuneCP5_13TeV-madgraphMLM-pythia8/RunIIFall17NanoAODv4-PU2017_12Apr2018_Nano14Dec2018_102X_mc2017_realistic_v6-v1/NANOAODSIM",   dbFile=dbFile, overwrite=ov, redirector=redirector, xSection=14.5805)
+WJetsToLNu_HT800to1200  = Sample.nanoAODfromDAS("WJetsToLNu_HT800to1200",  "/WJetsToLNu_HT-800To1200_TuneCP5_13TeV-madgraphMLM-pythia8/RunIIFall17NanoAODv4-PU2017_12Apr2018_Nano14Dec2018_102X_mc2017_realistic_v6-v1/NANOAODSIM",  dbFile=dbFile, overwrite=ov, redirector=redirector, xSection=6.65621)
+WJetsToLNu_HT1200to2500 = Sample.nanoAODfromDAS("WJetsToLNu_HT1200to2500", "/WJetsToLNu_HT-1200To2500_TuneCP5_13TeV-madgraphMLM-pythia8/RunIIFall17NanoAODv4-PU2017_12Apr2018_Nano14Dec2018_102X_mc2017_realistic_v6-v1/NANOAODSIM", dbFile=dbFile, overwrite=ov, redirector=redirector, xSection=1.60809)
+WJetsToLNu_HT2500toInf  = Sample.nanoAODfromDAS("WJetsToLNu_HT2500toInf",  "/WJetsToLNu_HT-2500ToInf_TuneCP5_13TeV-madgraphMLM-pythia8/RunIIFall17NanoAODv4-PU2017_12Apr2018_Nano14Dec2018_102X_mc2017_realistic_v6-v1/NANOAODSIM",  dbFile=dbFile, overwrite=ov, redirector=redirector, xSection=0.0389136)
+
+wjets_ht = [
+    #WJetsToLNu_HT70to100,
+    WJetsToLNu_HT100to200,
+    WJetsToLNu_HT200to400,
+    WJetsToLNu_HT400to600,
+    WJetsToLNu_HT600to800,
+    WJetsToLNu_HT800to1200,
+    WJetsToLNu_HT1200to2500,
+    WJetsToLNu_HT2500toInf,
+    ]
+
+wjets = wjets_inc + wjets_ht
 
 ## rare
 #TTTT = Sample.nanoAODfromDAS("TTTT", "/TTTT_TuneCP5_13TeV-amcatnlo-pythia8/RunIIFall17NanoAOD-PU2017_pilot_94X_mc2017_realistic_v14-v1/NANOAODSIM", dbFile=dbFile, redirector=redirector, xSection=0.009103, overwrite=ov)
@@ -295,9 +376,6 @@ rare = [
 #T2tt_mStop_650_mLSP_350 = Sample.nanoAODfromDAS("T2tt_mStop_650_mLSP_350", "/SMS-T2tt_mStop-650_mLSP-350_TuneCP5_13TeV-madgraphMLM-pythia8/RunIIFall17NanoAOD-PU2017_12Apr2018_94X_mc2017_realistic_v14-v1/NANOAODSIM", dbFile=dbFile, redirector=redirector, xSection=1, overwrite=ov)
 
 
-other = [
-    ]
-
 #GluGluToContinToZZTo2e2mu   = Sample.nanoAODfromDAS("GluGluToContinToZZTo2e2mu",   "/GluGluToContinToZZTo2e2mu_13TeV_MCFM701_pythia8/RunIIFall17NanoAOD-PU2017_12Apr2018_94X_mc2017_realistic_v14-v2/NANOAODSIM", dbFile=dbFile, redirector=redirector, xSection=0.005423, overwrite=ov)
 #GluGluToContinToZZTo2e2tau  = Sample.nanoAODfromDAS("GluGluToContinToZZTo2e2tau",  "/GluGluToContinToZZTo2e2tau_13TeV_MCFM701_pythia8/RunIIFall17NanoAOD-PU2017_12Apr2018_94X_mc2017_realistic_v14-v2/NANOAODSIM", dbFile=dbFile, redirector=redirector, xSection=0.005423, overwrite=ov)
 #GluGluToContinToZZTo2mu2tau = Sample.nanoAODfromDAS("GluGluToContinToZZTo2mu2tau", "/GluGluToContinToZZTo2mu2tau_13TeV_MCFM701_pythia8/RunIIFall17NanoAOD-PU2017_12Apr2018_94X_mc2017_realistic_v14-v2/NANOAODSIM", dbFile=dbFile, redirector=redirector, xSection=0.005423, overwrite=ov)
@@ -314,8 +392,67 @@ gluglu = [
 #    GluGluToContinToZZTo4tau,
 ]
 
+### QCD
 
-allSamples = DY + top + boson + wjets + rare + other + gluglu
+## QCD HT bins (cross sections from McM)
+
+#QCD_HT50to100    = Sample.nanoAODfromDAS("QCD_HT50to100",    "/QCD_HT50to100_TuneCUETP8M1_13TeV-madgraphMLM-pythia8/RunIISummer16NanoAOD-PUMoriond17_05Feb2018_94X_mcRun2_asymptotic_v2-v1/NANOAODSIM",         dbFile=dbFile, overwrite=ov, redirector=redirector, xSection=246400000.0) #NOTE: missing
+QCD_HT100to200   = Sample.nanoAODfromDAS("QCD_HT100to200",   "/QCD_HT100to200_TuneCP5_13TeV-madgraph-pythia8/RunIIFall17NanoAODv4-PU2017_12Apr2018_Nano14Dec2018_102X_mc2017_realistic_v6-v1/NANOAODSIM",         dbFile=dbFile, overwrite=ov, redirector=redirector, xSection=27850000.0)
+QCD_HT200to300   = Sample.nanoAODfromDAS("QCD_HT200to300",   "/QCD_HT200to300_TuneCP5_13TeV-madgraph-pythia8/RunIIFall17NanoAODv4-PU2017_12Apr2018_Nano14Dec2018_new_pmx_102X_mc2017_realistic_v6-v1/NANOAODSIM", dbFile=dbFile, overwrite=ov, redirector=redirector, xSection=1717000)
+QCD_HT300to500   = Sample.nanoAODfromDAS("QCD_HT300to500",   "/QCD_HT300to500_TuneCP5_13TeV-madgraph-pythia8/RunIIFall17NanoAODv4-PU2017_12Apr2018_Nano14Dec2018_102X_mc2017_realistic_v6-v1/NANOAODSIM",         dbFile=dbFile, overwrite=ov, redirector=redirector, xSection=351300)
+QCD_HT500to700   = Sample.nanoAODfromDAS("QCD_HT500to700",   "/QCD_HT500to700_TuneCP5_13TeV-madgraph-pythia8/RunIIFall17NanoAODv4-PU2017_12Apr2018_Nano14Dec2018_102X_mc2017_realistic_v6-v1/NANOAODSIM",         dbFile=dbFile, overwrite=ov, redirector=redirector, xSection=31630)
+QCD_HT700to1000  = Sample.nanoAODfromDAS("QCD_HT700to1000",  "/QCD_HT700to1000_TuneCP5_13TeV-madgraph-pythia8/RunIIFall17NanoAODv4-PU2017_12Apr2018_Nano14Dec2018_102X_mc2017_realistic_v6-v1/NANOAODSIM",        dbFile=dbFile, overwrite=ov, redirector=redirector, xSection=6802)
+QCD_HT1000to1500 = Sample.nanoAODfromDAS("QCD_HT1000to1500", "/QCD_HT1000to1500_TuneCP5_13TeV-madgraph-pythia8/RunIIFall17NanoAODv4-PU2017_12Apr2018_Nano14Dec2018_102X_mc2017_realistic_v6-v1/NANOAODSIM",       dbFile=dbFile, overwrite=ov, redirector=redirector, xSection=1206)
+QCD_HT1500to2000 = Sample.nanoAODfromDAS("QCD_HT1500to2000", "/QCD_HT1500to2000_TuneCP5_13TeV-madgraph-pythia8/RunIIFall17NanoAODv4-PU2017_12Apr2018_Nano14Dec2018_102X_mc2017_realistic_v6-v1/NANOAODSIM",       dbFile=dbFile, overwrite=ov, redirector=redirector, xSection=120.4)
+QCD_HT2000toInf  = Sample.nanoAODfromDAS("QCD_HT2000toInf",  "/QCD_HT2000toInf_TuneCP5_13TeV-madgraph-pythia8/RunIIFall17NanoAODv4-PU2017_12Apr2018_Nano14Dec2018_102X_mc2017_realistic_v6-v1/NANOAODSIM",        dbFile=dbFile, overwrite=ov, redirector=redirector, xSection=25.25)
+
+QCD = [
+    #QCD_HT50to100,
+    QCD_HT100to200,
+    QCD_HT200to300,
+    QCD_HT300to500,
+    QCD_HT500to700,
+    QCD_HT700to1000,
+    QCD_HT1000to1500,
+    QCD_HT1500to2000,
+    QCD_HT2000toInf,
+    ]
+
+### Zinv
+# NOTE: x-check xsecs (https://twiki.cern.ch/twiki/bin/view/CMS/SummaryTable1G25ns#DY_Z)
+
+ZJetsToNuNu_HT100to200   = Sample.nanoAODfromDAS("ZJetsToNuNu_HT100to200",   "/ZJetsToNuNu_HT-100To200_13TeV-madgraph/RunIIFall17NanoAODv4-PU2017_12Apr2018_Nano14Dec2018_102X_mc2017_realistic_v6-v1/NANOAODSIM",           dbFile=dbFile, overwrite=ov, redirector=redirector, xSection=344.9781)
+ZJetsToNuNu_HT200to400   = Sample.nanoAODfromDAS("ZJetsToNuNu_HT200to400",   "/ZJetsToNuNu_HT-200To400_13TeV-madgraph/RunIIFall17NanoAODv4-PU2017_12Apr2018_Nano14Dec2018_102X_mc2017_realistic_v6-v1/NANOAODSIM",           dbFile=dbFile, overwrite=ov, redirector=redirector, xSection=96.3828)
+ZJetsToNuNu_HT400to600   = Sample.nanoAODfromDAS("ZJetsToNuNu_HT400to600",   "/ZJetsToNuNu_HT-400To600_13TeV-madgraph/RunIIFall17NanoAODv4-PU2017_12Apr2018_Nano14Dec2018_new_pmx_102X_mc2017_realistic_v6-v1/NANOAODSIM",   dbFile=dbFile, overwrite=ov, redirector=redirector, xSection=13.4562)
+#ZJetsToNuNu_HT400to600   = Sample.nanoAODfromDAS("ZJetsToNuNu_HT400to600",   "/ZJetsToNuNu_HT-400To600_13TeV-madgraph/RunIIFall17NanoAODv4-PU2017_12Apr2018_Nano14Dec2018_102X_mc2017_realistic_v6-v1/NANOAODSIM",           dbFile=dbFile, overwrite=ov, redirector=redirector, xSection=13.4562) # NOTE: superseded by new pmx?
+ZJetsToNuNu_HT600to800   = Sample.nanoAODfromDAS("ZJetsToNuNu_HT600to800",   "/ZJetsToNuNu_HT-600To800_13TeV-madgraph/RunIIFall17NanoAODv4-PU2017_12Apr2018_Nano14Dec2018_new_pmx_102X_mc2017_realistic_v6-v1/NANOAODSIM",   dbFile=dbFile, overwrite=ov, redirector=redirector, xSection=3.96183)
+#ZJetsToNuNu_HT600to800   = Sample.nanoAODfromDAS("ZJetsToNuNu_HT600to800",   "/ZJetsToNuNu_HT-600To800_13TeV-madgraph/RunIIFall17NanoAODv4-PU2017_12Apr2018_Nano14Dec2018_102X_mc2017_realistic_v6-v1/NANOAODSIM",           dbFile=dbFile, overwrite=ov, redirector=redirector, xSection=3.96183) # NOTE: superseded by new pmx?
+ZJetsToNuNu_HT800to1200  = Sample.nanoAODfromDAS("ZJetsToNuNu_HT800to1200",  "/ZJetsToNuNu_HT-800To1200_13TeV-madgraph/RunIIFall17NanoAODv4-PU2017_12Apr2018_Nano14Dec2018_102X_mc2017_realistic_v6-v1/NANOAODSIM",          dbFile=dbFile, overwrite=ov, redirector=redirector, xSection=1.81302)
+ZJetsToNuNu_HT1200to2500 = Sample.nanoAODfromDAS("ZJetsToNuNu_HT1200to2500", "/ZJetsToNuNu_HT-1200To2500_13TeV-madgraph/RunIIFall17NanoAODv4-PU2017_12Apr2018_Nano14Dec2018_new_pmx_102X_mc2017_realistic_v6-v1/NANOAODSIM", dbFile=dbFile, overwrite=ov, redirector=redirector, xSection=0.441078)
+#ZJetsToNuNu_HT1200to2500 = Sample.nanoAODfromDAS("ZJetsToNuNu_HT1200to2500", "/ZJetsToNuNu_HT-1200To2500_13TeV-madgraph/RunIIFall17NanoAODv4-PU2017_12Apr2018_Nano14Dec2018_102X_mc2017_realistic_v6-v1/NANOAODSIM",         dbFile=dbFile, overwrite=ov, redirector=redirector, xSection=0.441078) # NOTE: superseded by new pmx?
+ZJetsToNuNu_HT2500toInf  = Sample.nanoAODfromDAS("ZJetsToNuNu_HT2500toInf",  "/ZJetsToNuNu_HT-2500ToInf_13TeV-madgraph/RunIIFall17NanoAODv4-PU2017_12Apr2018_Nano14Dec2018_102X_mc2017_realistic_v6-v1/NANOAODSIM",          dbFile=dbFile, overwrite=ov, redirector=redirector, xSection=0.01008969)
+
+Zinv = [
+    ZJetsToNuNu_HT100to200,
+    ZJetsToNuNu_HT200to400,
+    ZJetsToNuNu_HT400to600,
+    ZJetsToNuNu_HT600to800,
+    ZJetsToNuNu_HT800to1200,
+    ZJetsToNuNu_HT1200to2500,
+    ZJetsToNuNu_HT2500toInf,
+    ]
+
+### Signals
+signals = [
+    ]
+
+### Other
+other = [
+    ]
+
+allSamples = DY + top + boson + wjets + rare + gluglu + QCD + Zinv + signals + other
+
+soft1LepSamples = wjets + TTJets + Zinv + QCD + DYJetsM50HT + DYJetsM5to50HT + ST + TTV_LO + VV_NLO + signals
 
 for s in allSamples:
     s.isData = False

--- a/nanoAOD/python/Run2018_14Sep2018.py
+++ b/nanoAOD/python/Run2018_14Sep2018.py
@@ -39,15 +39,15 @@ logger.info("Using db file: %s", dbFile)
 # specify a local directory if you want to create (and afterwards automatically use) a local copy of the sample, otherwise use the grid.
 
 ## DoubleMuon
-DoubleMuon_Run2018A_14Sep2018_ver1  = Sample.nanoAODfromDAS("DoubleMuon_Run2018A_14Sep2018_ver1",   "/DoubleMuon/Run2018A-14Sep2018_ver1-v1/NANOAOD", dbFile=dbFile, overwrite=ov, redirector=redirector)
-DoubleMuon_Run2018A_14Sep2018_ver2  = Sample.nanoAODfromDAS("DoubleMuon_Run2018A_14Sep2018_ver2",   "/DoubleMuon/Run2018A-14Sep2018_ver2-v1/NANOAOD", dbFile=dbFile, overwrite=ov, redirector=redirector)
-DoubleMuon_Run2018A_14Sep2018_ver3  = Sample.nanoAODfromDAS("DoubleMuon_Run2018A_14Sep2018_ver3",   "/DoubleMuon/Run2018A-14Sep2018_ver3-v1/NANOAOD", dbFile=dbFile, overwrite=ov, redirector=redirector)
-DoubleMuon_Run2018B_14Sep2018_ver1  = Sample.nanoAODfromDAS("DoubleMuon_Run2018B_14Sep2018_ver1",   "/DoubleMuon/Run2018B-14Sep2018_ver1-v1/NANOAOD", dbFile=dbFile, overwrite=ov, redirector=redirector)
-DoubleMuon_Run2018B_14Sep2018_ver2  = Sample.nanoAODfromDAS("DoubleMuon_Run2018B_14Sep2018_ver2",   "/DoubleMuon/Run2018B-14Sep2018_ver2-v1/NANOAOD", dbFile=dbFile, overwrite=ov, redirector=redirector)
-DoubleMuon_Run2018C_14Sep2018_ver1  = Sample.nanoAODfromDAS("DoubleMuon_Run2018C_14Sep2018_ver1",   "/DoubleMuon/Run2018C-14Sep2018_ver1-v1/NANOAOD", dbFile=dbFile, overwrite=ov, redirector=redirector)
-DoubleMuon_Run2018C_14Sep2018_ver2  = Sample.nanoAODfromDAS("DoubleMuon_Run2018C_14Sep2018_ver2",   "/DoubleMuon/Run2018C-14Sep2018_ver2-v1/NANOAOD", dbFile=dbFile, overwrite=ov, redirector=redirector)
-DoubleMuon_Run2018C_14Sep2018_ver3  = Sample.nanoAODfromDAS("DoubleMuon_Run2018C_14Sep2018_ver3",   "/DoubleMuon/Run2018C-14Sep2018_ver3-v1/NANOAOD", dbFile=dbFile, overwrite=ov, redirector=redirector)
-DoubleMuon_Run2018D_14Sep2018_ver2  = Sample.nanoAODfromDAS("DoubleMuon_Run2018D_14Sep2018_ver2",   "/DoubleMuon/Run2018D-14Sep2018_ver2-v1/NANOAOD", dbFile=dbFile, overwrite=ov, redirector=redirector)
+DoubleMuon_Run2018A_14Sep2018_ver1  = Sample.nanoAODfromDAS("DoubleMuon_Run2018A_14Sep2018_ver1", "/DoubleMuon/Run2018A-14Sep2018_ver1-v1/NANOAOD", dbFile=dbFile, overwrite=ov, redirector=redirector)
+DoubleMuon_Run2018A_14Sep2018_ver2  = Sample.nanoAODfromDAS("DoubleMuon_Run2018A_14Sep2018_ver2", "/DoubleMuon/Run2018A-14Sep2018_ver2-v1/NANOAOD", dbFile=dbFile, overwrite=ov, redirector=redirector)
+DoubleMuon_Run2018A_14Sep2018_ver3  = Sample.nanoAODfromDAS("DoubleMuon_Run2018A_14Sep2018_ver3", "/DoubleMuon/Run2018A-14Sep2018_ver3-v1/NANOAOD", dbFile=dbFile, overwrite=ov, redirector=redirector)
+DoubleMuon_Run2018B_14Sep2018_ver1  = Sample.nanoAODfromDAS("DoubleMuon_Run2018B_14Sep2018_ver1", "/DoubleMuon/Run2018B-14Sep2018_ver1-v1/NANOAOD", dbFile=dbFile, overwrite=ov, redirector=redirector)
+DoubleMuon_Run2018B_14Sep2018_ver2  = Sample.nanoAODfromDAS("DoubleMuon_Run2018B_14Sep2018_ver2", "/DoubleMuon/Run2018B-14Sep2018_ver2-v1/NANOAOD", dbFile=dbFile, overwrite=ov, redirector=redirector)
+DoubleMuon_Run2018C_14Sep2018_ver1  = Sample.nanoAODfromDAS("DoubleMuon_Run2018C_14Sep2018_ver1", "/DoubleMuon/Run2018C-14Sep2018_ver1-v1/NANOAOD", dbFile=dbFile, overwrite=ov, redirector=redirector)
+DoubleMuon_Run2018C_14Sep2018_ver2  = Sample.nanoAODfromDAS("DoubleMuon_Run2018C_14Sep2018_ver2", "/DoubleMuon/Run2018C-14Sep2018_ver2-v1/NANOAOD", dbFile=dbFile, overwrite=ov, redirector=redirector)
+DoubleMuon_Run2018C_14Sep2018_ver3  = Sample.nanoAODfromDAS("DoubleMuon_Run2018C_14Sep2018_ver3", "/DoubleMuon/Run2018C-14Sep2018_ver3-v1/NANOAOD", dbFile=dbFile, overwrite=ov, redirector=redirector)
+DoubleMuon_Run2018D_14Sep2018_ver2  = Sample.nanoAODfromDAS("DoubleMuon_Run2018D_14Sep2018_ver2", "/DoubleMuon/Run2018D-14Sep2018_ver2-v1/NANOAOD", dbFile=dbFile, overwrite=ov, redirector=redirector)
 
 DoubleMuon_Run2018 = [\
     DoubleMuon_Run2018A_14Sep2018_ver1,
@@ -62,15 +62,15 @@ DoubleMuon_Run2018 = [\
     ]
 
 ## MuonEG
-MuonEG_Run2018A_14Sep2018_ver1  = Sample.nanoAODfromDAS("MuonEG_Run2018A_14Sep2018_ver1",   "/MuonEG/Run2018A-14Sep2018_ver1-v1/NANOAOD", dbFile=dbFile, overwrite=ov, redirector=redirector)
-MuonEG_Run2018A_14Sep2018_ver2  = Sample.nanoAODfromDAS("MuonEG_Run2018A_14Sep2018_ver2",   "/MuonEG/Run2018A-14Sep2018_ver2-v1/NANOAOD", dbFile=dbFile, overwrite=ov, redirector=redirector)
-MuonEG_Run2018A_14Sep2018_ver3  = Sample.nanoAODfromDAS("MuonEG_Run2018A_14Sep2018_ver3",   "/MuonEG/Run2018A-14Sep2018_ver3-v1/NANOAOD", dbFile=dbFile, overwrite=ov, redirector=redirector)
-MuonEG_Run2018B_14Sep2018_ver1  = Sample.nanoAODfromDAS("MuonEG_Run2018B_14Sep2018_ver1",   "/MuonEG/Run2018B-14Sep2018_ver1-v1/NANOAOD", dbFile=dbFile, overwrite=ov, redirector=redirector)
-MuonEG_Run2018B_14Sep2018_ver2  = Sample.nanoAODfromDAS("MuonEG_Run2018B_14Sep2018_ver2",   "/MuonEG/Run2018B-14Sep2018_ver2-v1/NANOAOD", dbFile=dbFile, overwrite=ov, redirector=redirector)
-MuonEG_Run2018C_14Sep2018_ver1  = Sample.nanoAODfromDAS("MuonEG_Run2018C_14Sep2018_ver1",   "/MuonEG/Run2018C-14Sep2018_ver1-v1/NANOAOD", dbFile=dbFile, overwrite=ov, redirector=redirector)
-MuonEG_Run2018C_14Sep2018_ver2  = Sample.nanoAODfromDAS("MuonEG_Run2018C_14Sep2018_ver2",   "/MuonEG/Run2018C-14Sep2018_ver2-v1/NANOAOD", dbFile=dbFile, overwrite=ov, redirector=redirector)
-MuonEG_Run2018C_14Sep2018_ver3  = Sample.nanoAODfromDAS("MuonEG_Run2018C_14Sep2018_ver3",   "/MuonEG/Run2018C-14Sep2018_ver3-v1/NANOAOD", dbFile=dbFile, overwrite=ov, redirector=redirector)
-MuonEG_Run2018D_14Sep2018_ver2  = Sample.nanoAODfromDAS("MuonEG_Run2018D_14Sep2018_ver2",   "/MuonEG/Run2018D-14Sep2018_ver2-v1/NANOAOD", dbFile=dbFile, overwrite=ov, redirector=redirector)
+MuonEG_Run2018A_14Sep2018_ver1  = Sample.nanoAODfromDAS("MuonEG_Run2018A_14Sep2018_ver1", "/MuonEG/Run2018A-14Sep2018_ver1-v1/NANOAOD", dbFile=dbFile, overwrite=ov, redirector=redirector)
+MuonEG_Run2018A_14Sep2018_ver2  = Sample.nanoAODfromDAS("MuonEG_Run2018A_14Sep2018_ver2", "/MuonEG/Run2018A-14Sep2018_ver2-v1/NANOAOD", dbFile=dbFile, overwrite=ov, redirector=redirector)
+MuonEG_Run2018A_14Sep2018_ver3  = Sample.nanoAODfromDAS("MuonEG_Run2018A_14Sep2018_ver3", "/MuonEG/Run2018A-14Sep2018_ver3-v1/NANOAOD", dbFile=dbFile, overwrite=ov, redirector=redirector)
+MuonEG_Run2018B_14Sep2018_ver1  = Sample.nanoAODfromDAS("MuonEG_Run2018B_14Sep2018_ver1", "/MuonEG/Run2018B-14Sep2018_ver1-v1/NANOAOD", dbFile=dbFile, overwrite=ov, redirector=redirector)
+MuonEG_Run2018B_14Sep2018_ver2  = Sample.nanoAODfromDAS("MuonEG_Run2018B_14Sep2018_ver2", "/MuonEG/Run2018B-14Sep2018_ver2-v1/NANOAOD", dbFile=dbFile, overwrite=ov, redirector=redirector)
+MuonEG_Run2018C_14Sep2018_ver1  = Sample.nanoAODfromDAS("MuonEG_Run2018C_14Sep2018_ver1", "/MuonEG/Run2018C-14Sep2018_ver1-v1/NANOAOD", dbFile=dbFile, overwrite=ov, redirector=redirector)
+MuonEG_Run2018C_14Sep2018_ver2  = Sample.nanoAODfromDAS("MuonEG_Run2018C_14Sep2018_ver2", "/MuonEG/Run2018C-14Sep2018_ver2-v1/NANOAOD", dbFile=dbFile, overwrite=ov, redirector=redirector)
+MuonEG_Run2018C_14Sep2018_ver3  = Sample.nanoAODfromDAS("MuonEG_Run2018C_14Sep2018_ver3", "/MuonEG/Run2018C-14Sep2018_ver3-v1/NANOAOD", dbFile=dbFile, overwrite=ov, redirector=redirector)
+MuonEG_Run2018D_14Sep2018_ver2  = Sample.nanoAODfromDAS("MuonEG_Run2018D_14Sep2018_ver2", "/MuonEG/Run2018D-14Sep2018_ver2-v1/NANOAOD", dbFile=dbFile, overwrite=ov, redirector=redirector)
 
 MuonEG_Run2018 = [\
     MuonEG_Run2018A_14Sep2018_ver1,
@@ -85,15 +85,15 @@ MuonEG_Run2018 = [\
     ]
 
 ## DoubleEG
-EGamma_Run2018A_14Sep2018_ver1  = Sample.nanoAODfromDAS("EGamma_Run2018A_14Sep2018_ver1",   "/EGamma/Run2018A-14Sep2018_ver1-v1/NANOAOD", dbFile=dbFile, overwrite=ov, redirector=redirector)
-EGamma_Run2018A_14Sep2018_ver2  = Sample.nanoAODfromDAS("EGamma_Run2018A_14Sep2018_ver2",   "/EGamma/Run2018A-14Sep2018_ver2-v1/NANOAOD", dbFile=dbFile, overwrite=ov, redirector=redirector)
-EGamma_Run2018A_14Sep2018_ver3  = Sample.nanoAODfromDAS("EGamma_Run2018A_14Sep2018_ver3",   "/EGamma/Run2018A-14Sep2018_ver3-v1/NANOAOD", dbFile=dbFile, overwrite=ov, redirector=redirector)
-EGamma_Run2018B_14Sep2018_ver1  = Sample.nanoAODfromDAS("EGamma_Run2018B_14Sep2018_ver1",   "/EGamma/Run2018B-14Sep2018_ver1-v1/NANOAOD", dbFile=dbFile, overwrite=ov, redirector=redirector)
-EGamma_Run2018B_14Sep2018_ver2  = Sample.nanoAODfromDAS("EGamma_Run2018B_14Sep2018_ver2",   "/EGamma/Run2018B-14Sep2018_ver2-v1/NANOAOD", dbFile=dbFile, overwrite=ov, redirector=redirector)
-EGamma_Run2018C_14Sep2018_ver1  = Sample.nanoAODfromDAS("EGamma_Run2018C_14Sep2018_ver1",   "/EGamma/Run2018C-14Sep2018_ver1-v1/NANOAOD", dbFile=dbFile, overwrite=ov, redirector=redirector)
-EGamma_Run2018C_14Sep2018_ver2  = Sample.nanoAODfromDAS("EGamma_Run2018C_14Sep2018_ver2",   "/EGamma/Run2018C-14Sep2018_ver2-v1/NANOAOD", dbFile=dbFile, overwrite=ov, redirector=redirector)
-EGamma_Run2018C_14Sep2018_ver3  = Sample.nanoAODfromDAS("EGamma_Run2018C_14Sep2018_ver3",   "/EGamma/Run2018C-14Sep2018_ver3-v1/NANOAOD", dbFile=dbFile, overwrite=ov, redirector=redirector)
-EGamma_Run2018D_14Sep2018_ver2  = Sample.nanoAODfromDAS("EGamma_Run2018D_14Sep2018_ver2",   "/EGamma/Run2018D-14Sep2018_ver2-v1/NANOAOD", dbFile=dbFile, overwrite=ov, redirector=redirector)
+EGamma_Run2018A_14Sep2018_ver1  = Sample.nanoAODfromDAS("EGamma_Run2018A_14Sep2018_ver1", "/EGamma/Run2018A-14Sep2018_ver1-v1/NANOAOD", dbFile=dbFile, overwrite=ov, redirector=redirector)
+EGamma_Run2018A_14Sep2018_ver2  = Sample.nanoAODfromDAS("EGamma_Run2018A_14Sep2018_ver2", "/EGamma/Run2018A-14Sep2018_ver2-v1/NANOAOD", dbFile=dbFile, overwrite=ov, redirector=redirector)
+EGamma_Run2018A_14Sep2018_ver3  = Sample.nanoAODfromDAS("EGamma_Run2018A_14Sep2018_ver3", "/EGamma/Run2018A-14Sep2018_ver3-v1/NANOAOD", dbFile=dbFile, overwrite=ov, redirector=redirector)
+EGamma_Run2018B_14Sep2018_ver1  = Sample.nanoAODfromDAS("EGamma_Run2018B_14Sep2018_ver1", "/EGamma/Run2018B-14Sep2018_ver1-v1/NANOAOD", dbFile=dbFile, overwrite=ov, redirector=redirector)
+EGamma_Run2018B_14Sep2018_ver2  = Sample.nanoAODfromDAS("EGamma_Run2018B_14Sep2018_ver2", "/EGamma/Run2018B-14Sep2018_ver2-v1/NANOAOD", dbFile=dbFile, overwrite=ov, redirector=redirector)
+EGamma_Run2018C_14Sep2018_ver1  = Sample.nanoAODfromDAS("EGamma_Run2018C_14Sep2018_ver1", "/EGamma/Run2018C-14Sep2018_ver1-v1/NANOAOD", dbFile=dbFile, overwrite=ov, redirector=redirector)
+EGamma_Run2018C_14Sep2018_ver2  = Sample.nanoAODfromDAS("EGamma_Run2018C_14Sep2018_ver2", "/EGamma/Run2018C-14Sep2018_ver2-v1/NANOAOD", dbFile=dbFile, overwrite=ov, redirector=redirector)
+EGamma_Run2018C_14Sep2018_ver3  = Sample.nanoAODfromDAS("EGamma_Run2018C_14Sep2018_ver3", "/EGamma/Run2018C-14Sep2018_ver3-v1/NANOAOD", dbFile=dbFile, overwrite=ov, redirector=redirector)
+EGamma_Run2018D_14Sep2018_ver2  = Sample.nanoAODfromDAS("EGamma_Run2018D_14Sep2018_ver2", "/EGamma/Run2018D-14Sep2018_ver2-v1/NANOAOD", dbFile=dbFile, overwrite=ov, redirector=redirector)
 
 EGamma_Run2018 = [\
     EGamma_Run2018A_14Sep2018_ver1,
@@ -109,15 +109,15 @@ EGamma_Run2018 = [\
 
 
 ## SingleMuon
-SingleMuon_Run2018A_14Sep2018_ver1  = Sample.nanoAODfromDAS("SingleMuon_Run2018A_14Sep2018_ver1",   "/SingleMuon/Run2018A-14Sep2018_ver1-v1/NANOAOD", dbFile=dbFile, overwrite=ov, redirector=redirector)
-SingleMuon_Run2018A_14Sep2018_ver2  = Sample.nanoAODfromDAS("SingleMuon_Run2018A_14Sep2018_ver2",   "/SingleMuon/Run2018A-14Sep2018_ver2-v1/NANOAOD", dbFile=dbFile, overwrite=ov, redirector=redirector)
-SingleMuon_Run2018A_14Sep2018_ver3  = Sample.nanoAODfromDAS("SingleMuon_Run2018A_14Sep2018_ver3",   "/SingleMuon/Run2018A-14Sep2018_ver3-v1/NANOAOD", dbFile=dbFile, overwrite=ov, redirector=redirector)
-SingleMuon_Run2018B_14Sep2018_ver1  = Sample.nanoAODfromDAS("SingleMuon_Run2018B_14Sep2018_ver1",   "/SingleMuon/Run2018B-14Sep2018_ver1-v1/NANOAOD", dbFile=dbFile, overwrite=ov, redirector=redirector)
-SingleMuon_Run2018B_14Sep2018_ver2  = Sample.nanoAODfromDAS("SingleMuon_Run2018B_14Sep2018_ver2",   "/SingleMuon/Run2018B-14Sep2018_ver2-v1/NANOAOD", dbFile=dbFile, overwrite=ov, redirector=redirector)
-SingleMuon_Run2018C_14Sep2018_ver1  = Sample.nanoAODfromDAS("SingleMuon_Run2018C_14Sep2018_ver1",   "/SingleMuon/Run2018C-14Sep2018_ver1-v1/NANOAOD", dbFile=dbFile, overwrite=ov, redirector=redirector)
-SingleMuon_Run2018C_14Sep2018_ver2  = Sample.nanoAODfromDAS("SingleMuon_Run2018C_14Sep2018_ver2",   "/SingleMuon/Run2018C-14Sep2018_ver2-v1/NANOAOD", dbFile=dbFile, overwrite=ov, redirector=redirector)
-SingleMuon_Run2018C_14Sep2018_ver3  = Sample.nanoAODfromDAS("SingleMuon_Run2018C_14Sep2018_ver3",   "/SingleMuon/Run2018C-14Sep2018_ver3-v1/NANOAOD", dbFile=dbFile, overwrite=ov, redirector=redirector)
-SingleMuon_Run2018D_14Sep2018_ver2  = Sample.nanoAODfromDAS("SingleMuon_Run2018D_14Sep2018_ver2",   "/SingleMuon/Run2018D-14Sep2018_ver2-v1/NANOAOD", dbFile=dbFile, overwrite=ov, redirector=redirector)
+SingleMuon_Run2018A_14Sep2018_ver1  = Sample.nanoAODfromDAS("SingleMuon_Run2018A_14Sep2018_ver1", "/SingleMuon/Run2018A-14Sep2018_ver1-v1/NANOAOD", dbFile=dbFile, overwrite=ov, redirector=redirector)
+SingleMuon_Run2018A_14Sep2018_ver2  = Sample.nanoAODfromDAS("SingleMuon_Run2018A_14Sep2018_ver2", "/SingleMuon/Run2018A-14Sep2018_ver2-v1/NANOAOD", dbFile=dbFile, overwrite=ov, redirector=redirector)
+SingleMuon_Run2018A_14Sep2018_ver3  = Sample.nanoAODfromDAS("SingleMuon_Run2018A_14Sep2018_ver3", "/SingleMuon/Run2018A-14Sep2018_ver3-v1/NANOAOD", dbFile=dbFile, overwrite=ov, redirector=redirector)
+SingleMuon_Run2018B_14Sep2018_ver1  = Sample.nanoAODfromDAS("SingleMuon_Run2018B_14Sep2018_ver1", "/SingleMuon/Run2018B-14Sep2018_ver1-v1/NANOAOD", dbFile=dbFile, overwrite=ov, redirector=redirector)
+SingleMuon_Run2018B_14Sep2018_ver2  = Sample.nanoAODfromDAS("SingleMuon_Run2018B_14Sep2018_ver2", "/SingleMuon/Run2018B-14Sep2018_ver2-v1/NANOAOD", dbFile=dbFile, overwrite=ov, redirector=redirector)
+SingleMuon_Run2018C_14Sep2018_ver1  = Sample.nanoAODfromDAS("SingleMuon_Run2018C_14Sep2018_ver1", "/SingleMuon/Run2018C-14Sep2018_ver1-v1/NANOAOD", dbFile=dbFile, overwrite=ov, redirector=redirector)
+SingleMuon_Run2018C_14Sep2018_ver2  = Sample.nanoAODfromDAS("SingleMuon_Run2018C_14Sep2018_ver2", "/SingleMuon/Run2018C-14Sep2018_ver2-v1/NANOAOD", dbFile=dbFile, overwrite=ov, redirector=redirector)
+SingleMuon_Run2018C_14Sep2018_ver3  = Sample.nanoAODfromDAS("SingleMuon_Run2018C_14Sep2018_ver3", "/SingleMuon/Run2018C-14Sep2018_ver3-v1/NANOAOD", dbFile=dbFile, overwrite=ov, redirector=redirector)
+SingleMuon_Run2018D_14Sep2018_ver2  = Sample.nanoAODfromDAS("SingleMuon_Run2018D_14Sep2018_ver2", "/SingleMuon/Run2018D-14Sep2018_ver2-v1/NANOAOD", dbFile=dbFile, overwrite=ov, redirector=redirector)
 
 SingleMuon_Run2018 = [\
     SingleMuon_Run2018A_14Sep2018_ver1,
@@ -131,7 +131,30 @@ SingleMuon_Run2018 = [\
     SingleMuon_Run2018D_14Sep2018_ver2,
     ]
 
-allSamples = DoubleMuon_Run2018 + MuonEG_Run2018 + EGamma_Run2018 + SingleMuon_Run2018
+## MET
+MET_Run2018A_14Sep2018_ver1  = Sample.nanoAODfromDAS("MET_Run2018A_14Sep2018_ver1", "/MET/Run2018A-14Sep2018_ver1-v1/NANOAOD", dbFile=dbFile, overwrite=ov, redirector=redirector)
+MET_Run2018A_14Sep2018_ver2  = Sample.nanoAODfromDAS("MET_Run2018A_14Sep2018_ver2", "/MET/Run2018A-14Sep2018_ver2-v1/NANOAOD", dbFile=dbFile, overwrite=ov, redirector=redirector)
+MET_Run2018A_14Sep2018_ver3  = Sample.nanoAODfromDAS("MET_Run2018A_14Sep2018_ver3", "/MET/Run2018A-14Sep2018_ver3-v1/NANOAOD", dbFile=dbFile, overwrite=ov, redirector=redirector)
+MET_Run2018B_14Sep2018_ver1  = Sample.nanoAODfromDAS("MET_Run2018B_14Sep2018_ver1", "/MET/Run2018B-14Sep2018_ver1-v1/NANOAOD", dbFile=dbFile, overwrite=ov, redirector=redirector)
+MET_Run2018B_14Sep2018_ver2  = Sample.nanoAODfromDAS("MET_Run2018B_14Sep2018_ver2", "/MET/Run2018B-14Sep2018_ver2-v1/NANOAOD", dbFile=dbFile, overwrite=ov, redirector=redirector)
+MET_Run2018C_14Sep2018_ver1  = Sample.nanoAODfromDAS("MET_Run2018C_14Sep2018_ver1", "/MET/Run2018C-14Sep2018_ver1-v1/NANOAOD", dbFile=dbFile, overwrite=ov, redirector=redirector)
+MET_Run2018C_14Sep2018_ver2  = Sample.nanoAODfromDAS("MET_Run2018C_14Sep2018_ver2", "/MET/Run2018C-14Sep2018_ver2-v1/NANOAOD", dbFile=dbFile, overwrite=ov, redirector=redirector)
+MET_Run2018C_14Sep2018_ver3  = Sample.nanoAODfromDAS("MET_Run2018C_14Sep2018_ver3", "/MET/Run2018C-14Sep2018_ver3-v1/NANOAOD", dbFile=dbFile, overwrite=ov, redirector=redirector)
+MET_Run2018D_14Sep2018_ver2  = Sample.nanoAODfromDAS("MET_Run2018D_14Sep2018_ver2", "/MET/Run2018D-14Sep2018_ver2-v1/NANOAOD", dbFile=dbFile, overwrite=ov, redirector=redirector)
+
+MET_Run2018 = [\
+    MET_Run2018A_14Sep2018_ver1,
+    MET_Run2018A_14Sep2018_ver2,
+    MET_Run2018A_14Sep2018_ver3,
+    MET_Run2018B_14Sep2018_ver1,
+    MET_Run2018B_14Sep2018_ver2,
+    MET_Run2018C_14Sep2018_ver1,
+    MET_Run2018C_14Sep2018_ver2,
+    MET_Run2018C_14Sep2018_ver3,
+    MET_Run2018D_14Sep2018_ver2,
+    ]
+
+allSamples = DoubleMuon_Run2018 + MuonEG_Run2018 + EGamma_Run2018 + SingleMuon_Run2018 + MET_Run2018
 
 for s in allSamples:
     s.json = os.path.expandvars("$CMSSW_BASE/src/Samples/Tools/data/json/Cert_314472-325175_13TeV_PromptReco_Collisions18_JSON.txt")

--- a/nanoAOD/python/Summer16_05Feb2018.py
+++ b/nanoAOD/python/Summer16_05Feb2018.py
@@ -45,6 +45,13 @@ DYJetsToLL_M50_ext2      = Sample.nanoAODfromDAS("DYJetsToLL_M50_ext2",    "/DYJ
 
 DYJetsToLL_M10to50_LO    = Sample.nanoAODfromDAS("DYJetsToLL_M10to50_LO",  "/DYJetsToLL_M-10to50_TuneCUETP8M1_13TeV-madgraphMLM-pythia8/RunIISummer16NanoAOD-PUMoriond17_05Feb2018_94X_mcRun2_asymptotic_v2-v1/NANOAODSIM",   dbFile=dbFile, overwrite=ov, redirector=redirector, xSection=18610)
 
+DY = [
+    DYJetsToLL_M50_LO_ext1,
+    DYJetsToLL_M50_LO_ext2,
+    DYJetsToLL_M50_ext2,
+    DYJetsToLL_M10to50_LO,
+    ]
+
 # DY HT bins, M_{ll} [50, inf]
 DYJetsToLL_M50_HT70to100      = Sample.nanoAODfromDAS("DYJetsToLL_M50_HT70to100",      "/DYJetsToLL_M-50_HT-70to100_TuneCUETP8M1_13TeV-madgraphMLM-pythia8/RunIISummer16NanoAOD-PUMoriond17_05Feb2018_94X_mcRun2_asymptotic_v2-v1/NANOAODSIM",         dbFile=dbFile, overwrite=ov, redirector=redirector, xSection=170.4*1.23)
 DYJetsToLL_M50_HT100to200     = Sample.nanoAODfromDAS("DYJetsToLL_M50_HT100to200",     "/DYJetsToLL_M-50_HT-100to200_TuneCUETP8M1_13TeV-madgraphMLM-pythia8/RunIISummer16NanoAOD-PUMoriond17_05Feb2018_94X_mcRun2_asymptotic_v2-v1/NANOAODSIM",        dbFile=dbFile, overwrite=ov, redirector=redirector, xSection=147.4*1.23)
@@ -95,12 +102,7 @@ DYJetsM5to50HT = [
     DYJetsToLL_M5to50_HT600toInf_ext
     ]
 
-DY = [
-    DYJetsToLL_M50_LO_ext1,
-    DYJetsToLL_M50_LO_ext2,
-    DYJetsToLL_M10to50_LO,
-    DYJetsToLL_M50_ext2,
-    ] + DYJetsM50HT + DYJetsM5to50HT
+DY += DYJetsM50HT + DYJetsM5to50HT
 
 ### TTbar
 TTbar        = Sample.nanoAODfromDAS("TTbar",        "/TT_TuneCUETP8M2T4_13TeV-powheg-pythia8/RunIISummer16NanoAOD-PUMoriond17_05Feb2018_94X_mcRun2_asymptotic_v2-v1/NANOAODSIM",                  dbFile=dbFile, overwrite=ov, redirector=redirector, xSection=831.762)
@@ -108,7 +110,7 @@ TTbar        = Sample.nanoAODfromDAS("TTbar",        "/TT_TuneCUETP8M2T4_13TeV-p
 TTLep_pow    = Sample.nanoAODfromDAS("TTLep_pow",    "/TTTo2L2Nu_TuneCUETP8M2_ttHtranche3_13TeV-powheg-pythia8/RunIISummer16NanoAOD-PUMoriond17_05Feb2018_94X_mcRun2_asymptotic_v2-v1/NANOAODSIM", dbFile=dbFile, overwrite=ov, redirector=redirector, xSection=831.762*((3*0.108)**2))
 
 ## TTbar+jets
-TTJets       = Sample.nanoAODfromDAS("TTJets",       "/TTJets_TuneCUETP8M2T4_13TeV-amcatnloFXFX-pythia8/RunIISummer16NanoAOD-PUMoriond17_05Feb2018_94X_mcRun2_asymptotic_v2-v1/NANOAODSIM",        dbFile=dbFile, overwrite=ov, redirector=redirector, xSection=831.762)
+TTJets_amcatnlo   = Sample.nanoAODfromDAS("TTJets_amcatnlo",   "/TTJets_TuneCUETP8M2T4_13TeV-amcatnloFXFX-pythia8/RunIISummer16NanoAOD-PUMoriond17_05Feb2018_94X_mcRun2_asymptotic_v2-v1/NANOAODSIM",          dbFile=dbFile, overwrite=ov, redirector=redirector, xSection=831.762)
 
 # leptonic
 TTJets_DiLept     = Sample.nanoAODfromDAS("TTJets_DiLept",     "/TTJets_DiLept_TuneCUETP8M1_13TeV-madgraphMLM-pythia8/RunIISummer16NanoAOD-PUMoriond17_05Feb2018_94X_mcRun2_asymptotic_v2-v1/NANOAODSIM",      dbFile=dbFile, overwrite=ov, redirector=redirector, xSection=87.31483776) # NOTE: genMET-150 version exists
@@ -120,7 +122,7 @@ TTJets_SingleLeptonFromTbar     = Sample.nanoAODfromDAS("TTJets_SingleLeptonFrom
 TTJets_SingleLeptonFromTbar_ext = Sample.nanoAODfromDAS("TTJets_SingleLeptonFromTbar_ext", "/TTJets_SingleLeptFromTbar_TuneCUETP8M1_13TeV-madgraphMLM-pythia8/RunIISummer16NanoAOD-PUMoriond17_05Feb2018_94X_mcRun2_asymptotic_v2_ext1-v1/NANOAODSIM", dbFile=dbFile, overwrite=ov, redirector=redirector, xSection=182.17540224) # NOTE: genMET-150 version exists
 
 TTJets = [
-    TTJets,
+    TTJets_amcatnlo,
     TTJets_DiLept,
     TTJets_DiLept_ext,
     TTJets_SingleLeptonFromT,
@@ -328,18 +330,19 @@ boson = [
 ### W+jets
 
 ## inclusive
-WJetsToLNu      = Sample.nanoAODfromDAS("WJetsToLNu",     "/WJetsToLNu_TuneCUETP8M1_13TeV-amcatnloFXFX-pythia8/RunIISummer16NanoAOD-PUMoriond17_05Feb2018_94X_mcRun2_asymptotic_v2-v1/NANOAODSIM",      dbFile=dbFile, overwrite=ov, redirector=redirector, xSection=3* 20508.9)
-WJetsToLNu_ext  = Sample.nanoAODfromDAS("WJetsToLNu_ext", "/WJetsToLNu_TuneCUETP8M1_13TeV-amcatnloFXFX-pythia8/RunIISummer16NanoAOD-PUMoriond17_05Feb2018_94X_mcRun2_asymptotic_v2_ext2-v1/NANOAODSIM", dbFile=dbFile, overwrite=ov, redirector=redirector, xSection=3* 20508.9)
+# LO
+WJetsToLNu     = Sample.nanoAODfromDAS("WJetsToLNu",     "/WJetsToLNu_TuneCUETP8M1_13TeV-madgraphMLM-pythia8/RunIISummer16NanoAOD-PUMoriond17_05Feb2018_94X_mcRun2_asymptotic_v2-v1/NANOAODSIM",       dbFile=dbFile, overwrite=ov, redirector=redirector, xSection=3*20508.9)
+WJetsToLNu_ext = Sample.nanoAODfromDAS("WJetsToLNu_ext", "/WJetsToLNu_TuneCUETP8M1_13TeV-madgraphMLM-pythia8/RunIISummer16NanoAOD-PUMoriond17_05Feb2018_94X_mcRun2_asymptotic_v2_ext2-v1/NANOAODSIM",  dbFile=dbFile, overwrite=ov, redirector=redirector, xSection=3*20508.9)
 
-## LO
-WJetsToLNu_LO     = Sample.nanoAODfromDAS("WJetsToLNu_LO",     "/WJetsToLNu_TuneCUETP8M1_13TeV-madgraphMLM-pythia8/RunIISummer16NanoAOD-PUMoriond17_05Feb2018_94X_mcRun2_asymptotic_v2-v1/NANOAODSIM",       dbFile=dbFile, overwrite=ov, redirector=redirector, xSection=3*20508.9)
-WJetsToLNu_LO_ext = Sample.nanoAODfromDAS("WJetsToLNu_LO_ext", "/WJetsToLNu_TuneCUETP8M1_13TeV-madgraphMLM-pythia8/RunIISummer16NanoAOD-PUMoriond17_05Feb2018_94X_mcRun2_asymptotic_v2_ext2-v1/NANOAODSIM",  dbFile=dbFile, overwrite=ov, redirector=redirector, xSection=3*20508.9)
+# NLO
+WJetsToLNu_amcatnlo      = Sample.nanoAODfromDAS("WJetsToLNu_amcatnlo",     "/WJetsToLNu_TuneCUETP8M1_13TeV-amcatnloFXFX-pythia8/RunIISummer16NanoAOD-PUMoriond17_05Feb2018_94X_mcRun2_asymptotic_v2-v1/NANOAODSIM",      dbFile=dbFile, overwrite=ov, redirector=redirector, xSection=3* 20508.9)
+WJetsToLNu_amcatnlo_ext  = Sample.nanoAODfromDAS("WJetsToLNu_amcatnlo_ext", "/WJetsToLNu_TuneCUETP8M1_13TeV-amcatnloFXFX-pythia8/RunIISummer16NanoAOD-PUMoriond17_05Feb2018_94X_mcRun2_asymptotic_v2_ext2-v1/NANOAODSIM", dbFile=dbFile, overwrite=ov, redirector=redirector, xSection=3* 20508.9)
 
 wjets_inc = [
     WJetsToLNu,
     WJetsToLNu_ext,
-    WJetsToLNu_LO,
-    WJetsToLNu_LO_ext,
+    WJetsToLNu_amcatnlo,
+    WJetsToLNu_amcatnlo_ext,
     ]
 
 ## HT-binned
@@ -432,6 +435,7 @@ gluglu = [
     ]
 
 ### QCD
+
 ## QCD HT bins (cross sections from McM)
 
 QCD_HT50to100        = Sample.nanoAODfromDAS("QCD_HT50to100",        "/QCD_HT50to100_TuneCUETP8M1_13TeV-madgraphMLM-pythia8/RunIISummer16NanoAOD-PUMoriond17_05Feb2018_94X_mcRun2_asymptotic_v2-v1/NANOAODSIM",         dbFile=dbFile, overwrite=ov, redirector=redirector, xSection=246400000.0)
@@ -499,7 +503,7 @@ Zinv = [
     ZJetsToNuNu_HT2500toInf,
     ]
 
-## Signals
+### Signals
 T2tt_mStop_850_mLSP_100 = Sample.nanoAODfromDAS("T2tt_mStop_850_mLSP_100", "/SMS-T2tt_mStop-850_mLSP-100_TuneCUETP8M1_13TeV-madgraphMLM-pythia8/RunIISummer16NanoAOD-PUMoriond17_05Feb2018_94X_mcRun2_asymptotic_v2-v1/NANOAODSIM", dbFile=dbFile, overwrite=ov, redirector=redirector, xSection=1)
 #T2tt_mStop_650_mLSP_350 = Sample.nanoAODfromDAS("T2tt_mStop_650_mLSP_350", "/SMS-T2tt_mStop-650_mLSP-350_TuneCUETP8M1_13TeV-madgraphMLM-pythia8/RunIISummer16NanoAOD-PUMoriond17_05Feb2018_94X_mcRun2_asymptotic_v2-v1/NANOAODSIM", dbFile=dbFile, overwrite=ov, redirector=redirector, xSection=1)
 T2tt_mStop_500_mLSP_325 = Sample.nanoAODfromDAS("T2tt_mStop_500_mLSP_325", "/SMS-T2tt_mStop-500_mLSP-325_TuneCUETP8M1_13TeV-madgraphMLM-pythia8/RunIISummer16NanoAOD-PUMoriond17_05Feb2018_94X_mcRun2_asymptotic_v2-v1/NANOAODSIM", dbFile=dbFile, overwrite=ov, redirector=redirector, xSection=1)
@@ -512,6 +516,7 @@ signals = [
 #    T2tt_mStop_325_mLSP_150,
     ]
 
+### Other
 other = [
     ]
 


### PR DESCRIPTION
- Added Fall17 (14Dec2018) NanoAOD samples for the Soft 1L analysis:
  - WJetsToLNu_HT*,
  - TTJets_SingleLept*, TTJets_DiLept*, TTJets_amcatnlo
  - QCD_HT*
  - ZJetsToNuNu_HT*
  - DYJetsToLL_M4to50_HT*,
  - DYJetsToLL_M50_HT*,
  - T*, TBar*,
  - WW*, WZ*, ZZ*

- Updated ST and WW xsec to NNLO for the Fall17 (14Dec2018) NanoAOD samples:
  - ST_tW: 35.6 -> 35.85
  - WWTo2L2Nu: 10.481 -> 12.178
  - WWToLNuQQ: 43.53 -> 49.997

- Added MET PD to Run2018 (14Sep2018) NanoAOD samples
- Renamed WJets and TTJets amcatnlo samples for Summer16 (05Feb2018) NanoAOD samples